### PR TITLE
enhance : generate all meetup links automatically

### DIFF
--- a/0/index.textile
+++ b/0/index.textile
@@ -2,6 +2,7 @@
 
 layout: record
 title: "#0 boot loader"
+date: 2012-07-21 (Sat)
 
 ---
 

--- a/1/index.textile
+++ b/1/index.textile
@@ -2,6 +2,7 @@
 
 layout: record
 title: "#1"
+date: 2012-08-18 (Sat)
 
 ---
 

--- a/10/index.textile
+++ b/10/index.textile
@@ -2,6 +2,7 @@
 
 layout: record
 title: "#10"
+date: 2013-06-15 (Sat)
 
 ---
 

--- a/11/index.textile
+++ b/11/index.textile
@@ -2,6 +2,7 @@
 
 layout: record
 title: "#11"
+date: 2013-07-20 (Sat)
 
 ---
 

--- a/12/index.textile
+++ b/12/index.textile
@@ -2,6 +2,7 @@
 
 layout: record
 title: "#12"
+date: 2013-08-24 (Sat)
 
 ---
 

--- a/2/index.textile
+++ b/2/index.textile
@@ -2,6 +2,7 @@
 
 layout: record
 title: "#2"
+date: 2012-09-22 (Sat)
 
 ---
 

--- a/3/index.textile
+++ b/3/index.textile
@@ -2,6 +2,7 @@
 
 layout: record
 title: "#3"
+date: 2012-10-27 (Sat)
 
 ---
 

--- a/4/index.textile
+++ b/4/index.textile
@@ -2,6 +2,7 @@
 
 layout: record
 title: "#4"
+date: 2012-12-01 (Sat)
 
 ---
 

--- a/5/index.textile
+++ b/5/index.textile
@@ -2,6 +2,7 @@
 
 layout: record
 title: "#5"
+date: 2013-01-19 (Sat)
 
 ---
 

--- a/6/index.textile
+++ b/6/index.textile
@@ -2,6 +2,7 @@
 
 layout: record
 title: "#6"
+date: 2013-02-16 (Sat)
 
 ---
 

--- a/7/index.textile
+++ b/7/index.textile
@@ -2,6 +2,7 @@
 
 layout: record
 title: "#7"
+date: 2013-03-30 (Sat)
 
 ---
 

--- a/8/index.textile
+++ b/8/index.textile
@@ -2,6 +2,7 @@
 
 layout: record
 title: "#8"
+date: 2013-04-20 (Sat)
 
 ---
 

--- a/9/index.textile
+++ b/9/index.textile
@@ -2,6 +2,7 @@
 
 layout: record
 title: "#9"
+date: 2013-05-25 (Sat)
 
 ---
 

--- a/_layouts/record.html
+++ b/_layouts/record.html
@@ -19,21 +19,7 @@
         <h1 class="header"><a href="../">Kanazawa.rb<br>Meetup</a></h1>
         <p class="header"></p>
 
-        <ul>
-          <li><a href="../0/">#0 2012-07-21 (Sat)</a></li>
-          <li><a href="../1/">#1 2012-08-18 (Sat)</a></li>
-          <li><a href="../2/">#2 2012-09-22 (Sat)</a></li>
-          <li><a href="../3/">#3 2012-10-27 (Sat)</a></li>
-          <li><a href="../4/">#4 2012-12-01 (Sat)</a></li>
-          <li><a href="../5/">#5 2013-01-19 (Sat)</a></li>
-          <li><a href="../6/">#6 2013-02-16 (Sat)</a></li>
-          <li><a href="../7/">#7 2013-03-30 (Sat)</a></li>
-          <li><a href="../8/">#8 2013-04-20 (Sat)</a></li>
-          <li><a href="../9/">#9 2013-05-25 (Sat)</a></li>
-          <li><a href="../10/">#10 2013-06-15 (Sat)</a></li>
-          <li><a href="../11/">#11 2013-07-20 (Sat)</a></li>
-          <li><a href="../12/">#12 2013-08-24 (Sat)</a></li>
-        </ul>
+        {% collection ../ %}
 
         <p class="header">This project is maintained by <a class="header name" href="/">kanazawarb</a></p>
 

--- a/_layouts/toplevel.html
+++ b/_layouts/toplevel.html
@@ -19,21 +19,7 @@
         <h1 class="header"><a href="./">Kanazawa.rb<br>Meetup</a></h1>
         <p class="header"></p>
 
-        <ul>
-          <li><a href="./0/">#0 2012-07-21 (Sat)</a></li>
-          <li><a href="./1/">#1 2012-08-18 (Sat)</a></li>
-          <li><a href="./2/">#2 2012-09-22 (Sat)</a></li>
-          <li><a href="./3/">#3 2012-10-27 (Sat)</a></li>
-          <li><a href="./4/">#4 2012-12-01 (Sat)</a></li>
-          <li><a href="./5/">#5 2013-01-19 (Sat)</a></li>
-          <li><a href="./6/">#6 2013-02-16 (Sat)</a></li>
-          <li><a href="./7/">#7 2013-03-30 (Sat)</a></li>
-          <li><a href="./8/">#8 2013-04-20 (Sat)</a></li>
-          <li><a href="./9/">#9 2013-05-25 (Sat)</a></li>
-          <li><a href="./10/">#10 2013-06-15 (Sat)</a></li>
-          <li><a href="./11/">#11 2013-07-20 (Sat)</a></li>
-          <li><a href="./12/">#12 2013-08-24 (Sat)</a></li>
-        </ul>
+        {% collection %}
 
         <p class="header">This project is maintained by <a class="header name" href="/">kanazawarb</a></p>
 

--- a/_plugins/collection_tag.rb
+++ b/_plugins/collection_tag.rb
@@ -1,0 +1,32 @@
+module Jekyll
+  class CollectionTag < Liquid::Tag
+    def initialize(tag, prefix, tokens)
+      @prefix = prefix.strip
+      super
+    end
+
+    def collection(context)
+      context.registers[:site].pages.select { |page|
+        page.instance_variable_get('@dir') =~ /\A\/[0-9]+\z/ and
+        page.name =~ %r{\Aindex.(textile|md)\z}
+      }.map { |page|
+        {
+          'seq'  => page.instance_variable_get('@dir').sub(/[^0-9]*([0-9]+)[^0-9]*/, '\1').to_i,
+          'date' => page.instance_variable_get('@data')['date']
+        }
+      }.sort_by { |page|
+        page['seq']
+      }
+    end
+
+    def render(context)
+      "<ul>" +
+        collection(context).map { |e|
+        "<li><a href='#{@prefix}#{e['seq']}/'>\##{e['seq']} #{e['date']}</a></li>"
+        }.join("\n") +
+        "</ul>"
+    end
+  end
+end
+
+Liquid::Template.register_tag('collection', Jekyll::CollectionTag)


### PR DESCRIPTION
- add 'collection' tag for auto-generate meetup links
- replace hand-made links by 'collection' tag
- add date string for 'front-matter' in each meetup pages

What about this ?
