### PR TITLE
add kramdown

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org'
 gem 'rake'
 gem 'jekyll', '> 1.0'
 gem 'RedCloth'
+gem 'kramdown'
 
 group :livereload do
   gem 'guard-livereload'


### PR DESCRIPTION
cloneして、rake serveしたんですが、エラーが出ました。
どうもkramdownがgem dependencyから削除されてるみたいです。
(https://github.com/mojombo/jekyll/pull/1498)

kramdownをGemfileに追加しました。
よろしくお願いします。
