### PR TITLE
要らないgemを削除して環境を再現しやすく

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,5 @@ source 'https://rubygems.org'
 
 gem 'rake'
 gem 'jekyll', '> 1.0'
-gem 'RedCloth'
 gem 'kramdown'
 gem 'travis'

--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,3 @@ gem 'jekyll', '> 1.0'
 gem 'RedCloth'
 gem 'kramdown'
 gem 'travis'
-gem 'hub', :github => 'github/hub', :tag => 'v1.12.2'
-
-group :livereload do
-  gem 'guard-livereload'
-end

--- a/README.md
+++ b/README.md
@@ -5,11 +5,7 @@
 
     bundle install --path vendor/bundle --binstubs .bundle/bin
 
-もしくは
-
-    bundle install --path vendor/bundle --binstubs .bundle/bin --without livereload
-
-( guard-livereload を install したくない場合 )
+( `guard-livereload` が必要な場合は global に install して使ってください )
 
 作業の進め方
 ------------


### PR DESCRIPTION
Jekyll を利用したサイト作成そのものには不要な以下の gem への依存を削除しました。

 * guard-livereload
 * RedCloth
 * Hub

これで環境再現には特に手間が掛からないのではないかと思います。