### PR TITLE
Slack招待用のバッジをリンクに変更

### DIFF
--- a/_layouts/toplevel.html
+++ b/_layouts/toplevel.html
@@ -17,7 +17,9 @@
     <div class="wrapper">
       <header>
         <h1 class="header"><a href="./">Kanazawa.rb<br>Meetup</a></h1>
-        <script async defer src="https://kzrb-slackin.herokuapp.com/slackin.js"></script>
+        <a href="https://kzrb-slackin.herokuapp.com">
+          <img id="slackin-badge" src="https://kzrb-slackin.herokuapp.com/badge.svg">
+        </a>
 
         <ul>
           <li><a href="./67/">#67 2018-03-17(Sat)</a></li>

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -149,6 +149,11 @@ img {
   border: 1px solid #ccc;
 }
 
+img#slackin-badge {
+  margin: 10px 0;
+  padding: 0;
+  border: none;
+}
 
 /* Code blocks */
 


### PR DESCRIPTION
iframeのbadge経由だと登録できないとのことなのでsvgを用いたリンクに変更しました
imgタグにデフォルトで枠がつくなどのCSSが適用されていたので、その影響を受けないようにstylesheet側も少し弄っています

<img width="371" alt="kzrb_slackin" src="https://user-images.githubusercontent.com/5707477/37552878-71a01db2-2a00-11e8-8e98-fa09a08d4efb.png">
