### PR TITLE
fix link of slackin button

### DIFF
--- a/_layouts/record.html
+++ b/_layouts/record.html
@@ -17,7 +17,9 @@
     <div class="wrapper">
       <header>
         <h1 class="header"><a href="../">Kanazawa.rb<br>Meetup</a></h1>
-        <script async defer src="https://kzrb-slackin.herokuapp.com/slackin.js"></script>
+        <a href="https://kzrb-slackin.herokuapp.com">
+          <img id="slackin-badge" src="https://kzrb-slackin.herokuapp.com/badge.svg">
+        </a>
 
         <ul>
           <li><a href="../72/">#72 2018-08-18(Sat)</a></li>


### PR DESCRIPTION
meetup71にてトップページ以外のslackinボタンのリンクが
修正されていないことが発覚したので、修正しました。

よろしくおねがいします。