### PR TITLE
meetup #100 以降に対応するため header li の幅を広げる

### DIFF
--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -212,7 +212,7 @@ td {
 header {
 	background-color: #171717;
 	color: #FDFDFB;
-  width:170px;
+  width:195px;
   float:left;
   position:absolute;
 	border: 1px solid #000;
@@ -222,7 +222,7 @@ header {
 	-moz-border-radius-bottomright: 4px;
 	border-top-right-radius: 4px;
 	border-bottom-right-radius: 4px;
-	padding: 34px 25px 22px 50px;
+	padding: 34px 25px 22px 25px;
 	margin: 30px 25px 0 0;
 	-webkit-font-smoothing: antialiased;
 }
@@ -259,8 +259,9 @@ header ul {
 }
 
 header li {
+  margin-left: 1rem;
+  margin-right: 1rem;
 	list-style-type: none;
-  width:132px;
   height:15px;
 	margin-bottom: 12px;
 	line-height: 1em;
@@ -398,6 +399,11 @@ footer {
 		margin-right: 0;
   }
 
+  header li {
+    margin-left: 2rem;
+    margin-right: 2rem;
+  }
+
 	section {
     padding:10px 0 10px 20px;
     margin:0 0 30px;
@@ -413,6 +419,11 @@ footer {
 }
 
 @media print, screen and (max-width: 480px) {
+
+  header li {
+    margin-left: 1rem;
+    margin-right: 1rem;
+  }
 
   header ul li.download {
     display:none;


### PR DESCRIPTION
## ■ 変更

 * header そのものが窮屈で content が実際の width を押し広げていたので実態に合わせて 195px に
 * 左の padding を削減
 * header li の width を固定しないように
 * 画面サイズに合わせながら li の margin を調整

## ■ 確認してもらいたいこと

 * Mobile の画面で li の右の余白が不格好に大きかったものも左右均等に近い形に変更したので違和感はだいぶ緩和されていると思います
 * Desktop / Mobile ( Portrait ) / Mobile ( Landscape ) でだいたいこんなもんかなという感じになっていること（ふんわり）
