### PR TITLE
リファクタリング： meetup のテンプレートを吐き出せるようにした

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,5 @@
 # -*- mode: ruby -*-
-require 'fileutils'
-require 'erb'
-require 'date'
+require_relative './lib/meetup'
 
 desc 'jekyll serve -w'
 task :serve do
@@ -56,42 +54,43 @@ task textile_to_md: [] do
 end
 
 namespace :meetup do
+  include Meetup
+
   desc 'create index.md template'
   task gen_index: [] do
     current_max = latest_meetup_count
-    previous = exist_index?(current_max) ? current_max : current_max - 1
+    previous_number = exist_index?(current_max) ? current_max : current_max - 1
 
-    puts "\e[1m#{previous}, 前回の開催日: #{previous_held_date(previous)}\e[0m"
+    puts "\e[1m#{previous_number}, 前回の開催日: #{previous_held_date(previous_number)}\e[0m"
 
-    next_time = previous + 1
+    next_time = previous_number + 1
 
-    is_yes = show_text "#{next_time} を作成しますか？ (Y)" do |val|
+    is_yes = say_and_gets("#{next_time} を作成しますか？ (Y)") {|val|
       /y/i =~ val
-    end
+    }
     next unless is_yes
 
     default_value = '## TODO ##'
 
-    doorkeeper_id = show_text 'Doorkeeper の event_id を入力してください' do |val|
+    doorkeeper_id = say_and_gets('Doorkeeper の event_id を入力してください') {|val|
       /\A\d+\z/.match?(val) ? val : default_value
-    end
+    }
 
-    next_date_ja = show_text '開催日を yyyy-mm-dd 形式で入力してください' do |val|
-      if /\A\d{4}-\d{2}-\d{2}\z/ =~ val
-        v = Date.parse(val)
-        day = '日月火水木金土'[v.wday]
-        v.strftime("%Y年%m月%d日(#{day})")
+    next_date_ja = say_and_gets('開催日を yyyy-mm-dd 形式で入力してください') {|val|
+      if /\A\d{4}-\d{2}-\d{2}\z/.match?(val)
+        format_date_ja(val)
       else
         default_value
       end
-    end
+    }
 
-    FileUtils.mkdir_p "#{next_time}"
-    index = ERB.new(File.read('./_meetup_template/index.md.erb')).result(binding)
-    File.write("./#{next_time}/index.md", index)
+    event = Event.new(number: next_time, template_name: 'index.md.erb') {|e|
+      e.render_text!(next_time: next_time, doorkeeper_id: doorkeeper_id, next_date_ja: next_date_ja)
+      e.generate_file(e.dest_dir, 'index.md')
+    }
 
     puts "#{next_time}/index.md が出力されました"
-    puts "\e[1m\e[31m## TODO ## のある箇所を実際の値に置換してください\e[0m" if %r|#{default_value}|.match?(index)
+    puts "\e[1m\e[31m## TODO ## のある箇所を実際の値に置換してください\e[0m" if %r|#{default_value}|.match?(event.text)
   end
 
   desc 'create report.md template'
@@ -105,40 +104,15 @@ namespace :meetup do
       next
     end
 
-    default_value = 'XXX'
-
-    report = ERB.new(File.read('./_meetup_template/report.md.erb')).result(binding)
-    File.write("./#{current_time}/report.md", report)
+    event = Event.new(number: current_time, template_name: 'report.md.erb') {|e|
+      e.render_text!(current_time: current_time)
+      e.generate_file(e.dest_dir, 'report.md')
+    }
 
     puts "#{current_time}/report.md が出力されました"
-    puts "\e[1m\e[31m#{current_time}/report.md 内の XXX となっている箇所を実際の値に置換してください\e[0m" if %r|#{default_value}|.match?(report)
+
+    default_value = 'XXX'
+    str = "\e[1m\e[31m#{current_time}/report.md 内の XXX となっている箇所を実際の値に置換してください\e[0m"
+    puts str if %r|#{default_value}|.match?(event.text)
   end
-end
-
-private
-
-def latest_meetup_count
-  Dir.glob('*').select {|e| /\d+/ =~ e }.map(&:to_i).max
-end
-
-def exist?(current_max, name)
-  File.exist?("#{current_max}/#{name}.md")
-end
-
-def exist_index?(current_max)
-  exist?(current_max, :index)
-end
-
-def exist_report?(current_max)
-  exist?(current_max, :report)
-end
-
-def previous_held_date(current_max)
-  File.read("#{current_max}/index.md").split("\n").select {|l| l =~ /\*\*日時\*\*/ }
-end
-
-def show_text(text)
-  puts text
-  val = $stdin.gets.chomp
-  yield val
 end

--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,3 @@
 layout: default
 markdown: kramdown
-exclude: [.git, .bundle, Gemfile, Gemfile.lock, README.md, _config.yml, _layouts, params.json, vendor]
+exclude: [.git, .bundle, Gemfile, Gemfile.lock, README.md, _config.yml, _layouts, params.json, vendor, lib]

--- a/lib/meetup.rb
+++ b/lib/meetup.rb
@@ -1,0 +1,69 @@
+require 'date'
+require 'erb'
+require 'fileutils'
+require 'pathname'
+
+module Meetup
+  ROOT_PATH = './'
+  TEMPLATE_PATH = './_meetup_template'
+
+  def latest_meetup_count
+    path = Pathname(ROOT_PATH).join('*')
+    Dir.glob(path).select {|e| /\d+/.match?(e) }.map(&:to_i).max
+  end
+
+  def previous_held_date(current_max)
+    path = Pathname(ROOT_PATH).join("#{current_max}/index.md")
+    File.read(path).split("\n").select {|l| /\*\*日時\*\*/.match?(l) }
+  end
+
+  def say_and_gets(text)
+    puts text
+    val = $stdin.gets.chomp
+    yield val
+  end
+
+  def format_date_ja(date_str)
+    v = Date.parse(date_str)
+    day = '日月火水木金土'[v.wday]
+    v.strftime("%Y年%m月%d日(#{day})")
+  end
+
+  def exist_index?(current_max)
+    exist?(current_max, :index)
+  end
+
+  def exist_report?(current_max)
+    exist?(current_max, :report)
+  end
+
+  private def exist?(current_max, name)
+    File.exist?("#{current_max}/#{name}.md")
+  end
+
+  class Event
+    attr_reader :text
+
+    def initialize(number:, template_name:)
+      @number = number
+      @template_name = template_name
+
+      yield self if block_given?
+    end
+
+    def render_text!(bind_hash)
+      source_path = Pathname(Meetup::TEMPLATE_PATH).join(@template_name)
+      @text = ERB.new(File.read(source_path)).result_with_hash(bind_hash)
+    end
+
+    def dest_dir
+      Pathname(Meetup::ROOT_PATH).join(@number.to_s)
+    end
+
+    def generate_file(dest_dir, dest_filename)
+      path = Pathname(dest_dir).join(dest_filename)
+      FileUtils.mkdir_p dest_dir
+      File.write(path, @text)
+    end
+  end
+end


### PR DESCRIPTION
#1199 のリファクタリングです。 

Rakefile にメソッドを定義するのを避けたかったため、lib ディレクトリ下にファイルを作成して、メソッドとクラスの定義をそちらに移しました。

ビルド後のファイルが格納される `_site` ディレクトリに lib 以下がコピーされないよう、 _config.yml の exclude に lib を追加しています。 