### PR TITLE
Nelify の badge を README に追加した

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Netlify Status](https://api.netlify.com/api/v1/badges/5369b4f4-7b1f-4bf6-8768-1cfe88b071e7/deploy-status)](https://app.netlify.com/sites/kzrb-org/deploys)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/77e1119d-dceb-4a1d-a4d1-cc4a4546385b/deploy-status)](https://app.netlify.com/sites/meetup-kzrb-org/deploys)
+
 まずやること
 ------------
 


### PR DESCRIPTION
https://kzrb.slack.com/archives/C02A6KL80/p1616291703009100?thread_ts=1616222692.007100&cid=C02A6KL80 共有してもらった badge を README に貼っています。

~~「kzrb.org のトップページ用」はkanazawarb/kanazawarb.github.com のことだと思われるので、そちらはそちらで PR します。~~ 一緒にこちらに出してしまいました。

区別できるようにしよかなと思ったのですが、不格好になったので、2 つそのまま表示しています。

バッジの確認具合は https://github.com/kanazawarb/meetup/blob/add-netlify-badge-to-readme/README.md でお願いします。