### PR TITLE
Dockerfile の Ruby を 2.7.3 まで上げた

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.2
+FROM ruby:2.7.3
 
 RUN useradd -m -u 1000 jekyll
 WORKDIR /tmp

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ $ docker build . -t meetup
 
 # ポート 4000 番でサーバを起動
 $ docker run -it -p 4000:4000 -p 35729:35729 -v $PWD:/tmp meetup
+
+# Rake task を実行する
+$ docker run --rm meetup bundle exec rake -T
 ```
 
 URL設計


### PR DESCRIPTION
### やったこと

脆弱性対応した Ruby 2.7.3 がリリースされたので、Docker のイメージの tagを2.7.3 に更新しました。
https://www.ruby-lang.org/ja/news/2021/04/05/ruby-2-7-3-released/

### 各自の環境でやってほしいこと

Gemfile.lock を一度削除し、再度 `bundle install` もしくは `docker build . -t meetup` する。 

#### Why?

kramdown が rexml に依存しており、上の URL 内にある、https://www.ruby-lang.org/en/news/2021/04/05/xml-round-trip-vulnerability-in-rexml-cve-2021-28965/ を見ると、脆弱性への対応は rexml 3.2.5 で対応されています。
Dockerfile の Ruby が上がって再ビルドしたとしても、ローカルの環境に作成されている Gemfile.lock に記録されているバージョンにしたがって rexml がインストールされてしまうため、一旦Gemfile.lockを削除しないと3.2.5 までは上がらないため。

 Dockerfile の設定で gem は system に入るが処理は一般ユーザで実行するようになっているため、`docker run` で `bundle update` しようとすると、gem を保存している ディレクトリに書き込む権限がないために失敗するため、Gemfile.lock を削除する方法を提案するに至っています。