### PR TITLE
DockerコマンドをMakefileに移行

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+current_dir := $(notdir $(shell pwd))
+
+#
+# meetup用コンテナのイメージをビルドする
+#
+.PHONY: build
+build:
+	docker build . -t meetup
+
+#
+# ポート番号4000番でサーバコンテナを起動する
+#
+.PHONY: up
+up:
+	docker run -it -p 4000:4000 -p 35729:35729 -v $(current_dir):/tmp meetup
+
+#
+# イベントの index.md のテンプレートを出力する
+#
+.PHONY: index
+index:
+	docker run -it -v $(current_dir):/tmp meetup bundle exec rake meetup:gen_index
+
+#
+# イベントの report.md のテンプレートを出力する
+#
+.PHONY: report
+report:
+	docker run -it -v $(current_dir):/tmp meetup bundle exec rake meetup:gen_report

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-current_dir := $(notdir $(shell pwd))
-
 #
 # meetup用コンテナのイメージをビルドする
 #
@@ -12,18 +10,18 @@ build:
 #
 .PHONY: up
 up:
-	docker run -it -p 4000:4000 -p 35729:35729 -v $(current_dir):/tmp meetup
+	docker run -it -p 4000:4000 -p 35729:35729 -v $(PWD):/tmp meetup
 
 #
 # イベントの index.md のテンプレートを出力する
 #
 .PHONY: index
 index:
-	docker run -it -v $(current_dir):/tmp meetup bundle exec rake meetup:gen_index
+	docker run -it -v $(PWD):/tmp meetup bundle exec rake meetup:gen_index
 
 #
 # イベントの report.md のテンプレートを出力する
 #
 .PHONY: report
 report:
-	docker run -it -v $(current_dir):/tmp meetup bundle exec rake meetup:gen_report
+	docker run -it -v $(PWD):/tmp meetup bundle exec rake meetup:gen_report

--- a/README.md
+++ b/README.md
@@ -24,15 +24,23 @@ Dockerで動かしたい場合
 ```
 # イメージをビルド
 $ docker build . -t meetup
+# もしくは
+$ make build
 
 # ポート 4000 番でサーバを起動
 $ docker run -it -p 4000:4000 -p 35729:35729 -v $PWD:/tmp meetup
+# もしくは
+$ make up
 
 # イベントの index.md のテンプレートを出力する
 $ docker run -it -v $PWD:/tmp meetup bundle exec rake meetup:gen_index
+# もしくは
+$ make index
 
 # イベントの report.md のテンプレートを出力する
 $ docker run -it -v $PWD:/tmp meetup bundle exec rake meetup:gen_report
+# もしくは
+$ make report
 ```
 
 URL設計

--- a/README.md
+++ b/README.md
@@ -23,23 +23,15 @@ Dockerで動かしたい場合
 ---------------------
 ```
 # イメージをビルド
-$ docker build . -t meetup
-# もしくは
 $ make build
 
 # ポート 4000 番でサーバを起動
-$ docker run -it -p 4000:4000 -p 35729:35729 -v $PWD:/tmp meetup
-# もしくは
 $ make up
 
 # イベントの index.md のテンプレートを出力する
-$ docker run -it -v $PWD:/tmp meetup bundle exec rake meetup:gen_index
-# もしくは
 $ make index
 
 # イベントの report.md のテンプレートを出力する
-$ docker run -it -v $PWD:/tmp meetup bundle exec rake meetup:gen_report
-# もしくは
 $ make report
 ```
 


### PR DESCRIPTION
## やったこと
muryoimpl大先生が作成したDocker環境関連の４つのコマンドをMakefileに記述しました。
これによって、Docker関連の実行コマンドを簡略化出来ます。
```
# イメージをビルド
$ make build
# ポート 4000 番でサーバを起動
$ make up
# イベントの index.md のテンプレートを出力する
$ make index
# イベントの report.md のテンプレートを出力する
$ make report
```