### PR TITLE
ビルド時に含めないファイルを追加した

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,3 @@
 layout: default
 markdown: kramdown
-exclude: [.git, .bundle, Gemfile, Gemfile.lock, README.md, _config.yml, _layouts, params.json, vendor, lib, Dockerfile]
+exclude: [.git, .bundle, Gemfile, Gemfile.lock, README.md, _config.yml, _layouts, params.json, vendor, lib, Dockerfile, Makefile, Rakefile]


### PR DESCRIPTION
(Netlifyの動作確認を含め) Rakefile と Makefile をビルドの対象ファイルから除外しました。これらは公開されているサイトからダウンロードできなくてもよさそう。


参考: 
- Jekyll Configuration Options: https://jekyllrb.com/docs/configuration/options/