### PR TITLE
Update Ruby version to 3.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.3
+FROM ruby:3.0.2
 
 RUN useradd -m -u 1000 jekyll
 WORKDIR /tmp

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@
 
 source 'https://rubygems.org'
 
+gem 'webrick'
 gem 'rake'
 gem 'jekyll', '> 1.0'
 gem 'kramdown'


### PR DESCRIPTION
Docker で使う Ruby を 3.0.2 まで上げてみました。

Netlify で使っているバージョンと乖離しているのは以前からそうだと思うので
気にしないことにしました :sweat: 

Ruby 3 になったことにより、webrick が標準添付から削除されたため、Gemfile に
 `gem 'webrick'` を足しています。
https://www.ruby-lang.org/ja/news/2020/12/25/ruby-3-0-0-released/

webrick は jekyll をローカルで実行する際に動かすアプリケーションサーバとして
使われています。