### PR TITLE
Slackのinvitation linkを置き換える

### DIFF
--- a/_includes/slack_link.html
+++ b/_includes/slack_link.html
@@ -1,0 +1,6 @@
+<div>
+  <a href="https://join.slack.com/t/kzrb/shared_invite/zt-1f4tcvoud-w5whpsFrRpFyFHisVpyMCA" rel="noopener" target="_blank" style="text-decoration:none;">
+    <img src="https://cdn.bfldr.com/5H442O3W/at/pl546j-7le8zk-afym5u/Slack_Mark_Web.png?auto=webp&amp;format=png&amp;width=100&amp;height=100" style="display:inline-block;margin:0;padding:0;border:none;" width="25px" height="25px">
+    <span style="display: inline-block;font-size:0.75rem;vertical-align:top;font-weight:400;">Slackに参加する</span>
+  </a>
+</div>

--- a/_layouts/record.html
+++ b/_layouts/record.html
@@ -17,9 +17,7 @@
     <div class="wrapper">
       <header>
         <h1 class="header"><a href="../">Kanazawa.rb<br>Meetup</a></h1>
-        <a href="https://kzrb-slackin.herokuapp.com">
-          <img id="slackin-badge" src="https://kzrb-slackin.herokuapp.com/badge.svg">
-        </a>
+        {% include slack_link.html %}
 
         <ul>
           <li><a href="../120/">#120 2022-08-27(Sat)</a></li>

--- a/_layouts/toplevel.html
+++ b/_layouts/toplevel.html
@@ -17,9 +17,7 @@
     <div class="wrapper">
       <header>
         <h1 class="header"><a href="./">Kanazawa.rb<br>Meetup</a></h1>
-        <a href="https://kzrb-slackin.herokuapp.com">
-          <img id="slackin-badge" src="https://kzrb-slackin.herokuapp.com/badge.svg">
-        </a>
+        {% include slack_link.html %}
 
         <ul>
           <li><a href="./120/">#120 2022-08-27(Sat)</a></li>


### PR DESCRIPTION
Slackin の従来の数字が表示されていた SVG へのリンクが切れていたので、別のリンクを用意しました。
<img width="532" alt="image" src="https://user-images.githubusercontent.com/318352/187440358-c6536994-1170-4891-b50a-1675aa15e1fa.png">



どうせ置き換わるからとスタイルは style に直接書いています。
リンクは Slack の招待リンクが作れたのでそちらで生成したものにしています。

| PC | SP |
| -- | -- |
| <img width="673" alt="image" src="https://user-images.githubusercontent.com/318352/187439859-6d180fda-06b4-4d6f-9fae-05cb60ce0153.png"> | <img width="433" alt="image" src="https://user-images.githubusercontent.com/318352/187439650-ffde4c7d-3094-4a40-99fb-84b2f0dcf4f7.png"> |
