### PR TITLE
Topに最新回であるmeetupへのリンクを出力するようにした

### DIFF
--- a/_posts/index.md
+++ b/_posts/index.md
@@ -4,6 +4,7 @@ title: Home
 nav_order: 1
 permalink: /
 ---
+<div></div>
 
 <p style="text-align: right;">
   <a href="./howto-make-meetup">→ How to make meetup</a>

--- a/_posts/index.md
+++ b/_posts/index.md
@@ -4,7 +4,12 @@ title: Home
 nav_order: 1
 permalink: /
 ---
-<div></div>
+<div>
+  <p class="d-inline-block label label-red ml-0">注目</p>
+  <a href="/120" class="home__latest-meetup-link">
+    最新の Meetup#120 はこちらへ
+  </a>
+</div>
 
 <p style="text-align: right;">
   <a href="./howto-make-meetup">→ How to make meetup</a>

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -109,3 +109,10 @@ ul.slides {
   vertical-align: middle;
   text-transform: none !important;
 }
+
+// home
+.home__latest-meetup-link {
+  display: inline-block;
+  vertical-align: middle;
+  line-height: 25px;
+}

--- a/lib/tasks/meetup.rb
+++ b/lib/tasks/meetup.rb
@@ -86,6 +86,21 @@ module Meetup
 
         doc.sub!("<ul>\n", "<ul>\n#{card_html}\n")
       end
+
+      add_event File.join(ROOT_PATH, "./_posts/index.md") do |doc|
+        return if already_exist_event?(doc)
+
+        html = <<~HTML
+        <div>
+          <p class="d-inline-block label label-red ml-0">注目</p>
+          <a href="/#{next_time}" class="home__latest-meetup-link">
+            最新の Meetup##{next_time} はこちらへ
+          </a>
+        </div>
+        HTML
+
+        doc.sub!(%r{<div>(\w|\W)*</div>}, html.chomp)
+      end
     end
 
     private


### PR DESCRIPTION
`bundle exec rake meetup:gen_index`, `make index` したときに、(雑だけど) Top ページに 最新回へのリンクを出力するようにしてみた。

| SP | PC |
| -- | -- |
| ![2022-09-03_134903_scrot](https://user-images.githubusercontent.com/318352/188256278-c7203ab4-77ac-4a07-92c9-a1ea8ac26578.png) | ![2022-09-03_134803_scrot](https://user-images.githubusercontent.com/318352/188256262-d452d44c-aafc-47fd-bf5b-e94261486bef.png) |
