### PR TITLE
ノベルティページを追加した

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,7 +27,7 @@ exclude:
 theme: just-the-docs
 
 # Set a path/url to a logo that will be displayed instead of the title
-logo: "/images/logo_kzrb.png"
+logo: "https://meetup.kzrb.org/images/logo_kzrb.png"
 
 # Enable or disable the site search
 # Supports true (default) or false
@@ -120,3 +120,21 @@ compress_html:
   # ignore:
   #   envs: all
   #
+twitter:
+  username: kanazawarb
+  card: summary
+
+author:
+  twitter: kanazawarb
+
+locale: ja_JP
+
+defaults:
+  - scope:
+      path: ""
+    values:
+      image:
+        path: https://meetup.kzrb.org/images/logo_kzrb.png
+        height: 200
+        width: 200
+        alt: kanazawa.rb logo

--- a/_posts/souvenirs.md
+++ b/_posts/souvenirs.md
@@ -1,0 +1,62 @@
+---
+layout: default
+title: Souvenirs
+nav_order: 5
+---
+
+# 過去の周年ノベルティ
+
+
+## 10周年記念（ステッカー）
+
+![](/120/sticker.jpg)
+Created by [@ichigami](https://twitter.com/ichigami/) from [15VISION](https://15vision.jp/)
+
+## 9周年記念（Tシャツ他）
+
+[SUZURI の kanazawa.rb](https://suzuri.jp/kzrb) ←こちらから買えます
+
+<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//suzuri.jp/thirdparty/widgets.js";js.charset="utf-8";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","suzuri-widget-script");</script>
+<div class="suzuri-widget-product" data-suzuri-product-id="19185143" data-suzuri-item-variant-id="11"><a href="https://suzuri.jp/kzrb/7715638/t-shirt/s/natural"><img src="https://d1q9av5b648rmv.cloudfront.net/v3/323x323/t-shirt/s/natural/front/7715638/1627714757-5572x2306.png.jpg?h=2d6cfe158138835c86dc58b483d453c6a2ac1377&amp;printed=true" width="323" height="323"></a></div>
+
+
+## 8周年記念（Zoomバーチャル背景）
+
+![](https://15vision.jp/archives/001/202008/large-108a9f488b0c0db73589f7ae6a22f05f48e0d63741a9299bf5ec044591d1629a.jpg)
+
+[https://15vision.jp/design-tools/kzrb.html](https://15vision.jp/design-tools/kzrb.html)
+
+Created by [@ichigami](https://twitter.com/ichigami/) from [15VISION](https://15vision.jp/)
+
+## 7周年記念（名入オーク木製コースター）
+
+![](https://user-images.githubusercontent.com/340622/61712962-7027d580-ad92-11e9-8df5-8ca4f20a999c.jpg)
+from [issue#1025](https://github.com/kanazawarb/meetup/issues/1025#issuecomment-514192554)
+
+## 6周年記念（カラビナ・キーホルダー）
+
+![](https://user-images.githubusercontent.com/340622/43372510-8cf9c716-93dc-11e8-8565-c22965e1a5cb.jpg)
+from [issue#879](https://github.com/kanazawarb/meetup/issues/879#issuecomment-408718030)
+
+## 5周年記念（キーホルダーサイズの栓抜き）
+
+![](https://user-images.githubusercontent.com/340622/27721385-ee8e85e4-5d9a-11e7-9c5c-44a1f98a3cf0.jpg)
+from [issue#733](https://github.com/kanazawarb/meetup/issues/733)
+
+## 4周年記念 (手ぬぐい)
+
+![](https://pbs.twimg.com/media/CqHjUylVUAACgf4?format=jpg&name=large)
+
+from [This tweet](https://twitter.com/Yukimitsu_Izawa/status/766143393135140864)
+
+## 3周年記念 (コースター)
+
+![](https://pbs.twimg.com/media/CNjBTp-UwAApMab?format=jpg&name=4096x4096)
+
+from [This tweet](https://twitter.com/Yukimitsu_Izawa/status/637471896066392064)
+
+## 2周年記念 (缶バッジ)
+
+![](https://pbs.twimg.com/media/BwQgmg9CEAA_9hV?format=jpg&name=900x900)
+
+from [This tweet](https://twitter.com/Yukimitsu_Izawa/status/505564904426717184)


### PR DESCRIPTION
過去の issue から画像等のリンクを探してきて集めたページを用意してみました。
@izawa さんの画像リンク提供により、2 周年以降の情報はとれましたので反映しています。

og:imageをロゴで設定したので、facebook で 各URL 書くとロゴが見えるようになったんじゃないかな、と思います。
twitter:image も設定してるけど、反映が遅そう…&変にキャッシュが残ってそう…というのがあり、facebook での確認でよさそう。


1 周年のノベルティ写真ありました！というのであれば、写真 or URL 等いただければ引き続き反映します。


ノベルティ集めたページのURLは↓で、メニューに「Souvenirs」とあるリンクがそれになっています
https://deploy-preview-1301--meetup-kzrb-org.netlify.app/souvenirs/
