### PR TITLE
_posts/ 以下のmarkdownにあるSlack の invitation URL を新しいものに置き換えた

### DIFF
--- a/_posts/100/index.md
+++ b/_posts/100/index.md
@@ -44,7 +44,7 @@ Kanazawa.rb の meetup イベントもついに100回目を迎えることにな
 * Zoom と同時にテキストチャットルームも活用します。
     * 発表に対するフィードバックや URL の共有等に利用します。
     * Slack というサービスの [Kanazawa.rb 用ワークスペース内](https://kzrb.slack.com/) にある `#meetup100` チャネルにご参加ください。
-    * アカウントの新規発行をご希望の方は [こちら](https://kzrb-slackin.herokuapp.com/) から登録ください。
+    * アカウントの新規発行をご希望の方は [こちら](https://join.slack.com/t/kzrb/shared_invite/zt-1f4tcvoud-w5whpsFrRpFyFHisVpyMCA) から登録ください。
     * Slack はイベントを補助するものであり、本 meetup への参加に Slack 登録は必須ではありません。
 
 

--- a/_posts/101/index.md
+++ b/_posts/101/index.md
@@ -42,7 +42,7 @@ Kanazawa.rbの意識高いもくもく会には以下のような特徴があり
 * Zoom と同時にテキストチャットルームも活用します。
     * 発表に対するフィードバックや URL の共有等に利用します。
     * Slack というサービスの [Kanazawa.rb 用ワークスペース内](https://kzrb.slack.com/) にある `#meetup101` チャネルにご参加ください。
-    * アカウントの新規発行をご希望の方は [こちら](https://kzrb-slackin.herokuapp.com/) から登録ください。
+    * アカウントの新規発行をご希望の方は [こちら](https://join.slack.com/t/kzrb/shared_invite/zt-1f4tcvoud-w5whpsFrRpFyFHisVpyMCA) から登録ください。
     * Slack はイベントを補助するものであり、本 meetup への参加に Slack 登録は必須ではありません。
 
 

--- a/_posts/102/index.md
+++ b/_posts/102/index.md
@@ -42,7 +42,7 @@ Kanazawa.rbの意識高いもくもく会には以下のような特徴があり
 * Zoom と同時にテキストチャットルームも活用します。
     * 発表に対するフィードバックや URL の共有等に利用します。
     * Slack というサービスの [Kanazawa.rb 用ワークスペース内](https://kzrb.slack.com/) にある `#meetup102` チャネルにご参加ください。
-    * アカウントの新規発行をご希望の方は [こちら](https://kzrb-slackin.herokuapp.com/) から登録ください。
+    * アカウントの新規発行をご希望の方は [こちら](https://join.slack.com/t/kzrb/shared_invite/zt-1f4tcvoud-w5whpsFrRpFyFHisVpyMCA) から登録ください。
     * Slack はイベントを補助するものであり、本 meetup への参加に Slack 登録は必須ではありません。
 
 

--- a/_posts/103/index.md
+++ b/_posts/103/index.md
@@ -42,7 +42,7 @@ Kanazawa.rbの意識高いもくもく会には以下のような特徴があり
 * Zoom と同時にテキストチャットルームも活用します。
     * 発表に対するフィードバックや URL の共有等に利用します。
     * Slack というサービスの [Kanazawa.rb 用ワークスペース内](https://kzrb.slack.com/) にある `#meetup103` チャネルにご参加ください。
-    * アカウントの新規発行をご希望の方は [こちら](https://kzrb-slackin.herokuapp.com/) から登録ください。
+    * アカウントの新規発行をご希望の方は [こちら](https://join.slack.com/t/kzrb/shared_invite/zt-1f4tcvoud-w5whpsFrRpFyFHisVpyMCA) から登録ください。
     * Slack はイベントを補助するものであり、本 meetup への参加に Slack 登録は必須ではありません。
 
 

--- a/_posts/104/index.md
+++ b/_posts/104/index.md
@@ -46,7 +46,7 @@ published: true
 * Zoom と同時にテキストチャットルームも活用します。
     * 発表に対するフィードバックや URL の共有等に利用します。
     * Slack というサービスの [Kanazawa.rb 用ワークスペース内](https://kzrb.slack.com/) にある `#meetup104` チャネルにご参加ください。
-    * アカウントの新規発行をご希望の方は [こちら](https://kzrb-slackin.herokuapp.com/) から登録ください。
+    * アカウントの新規発行をご希望の方は [こちら](https://join.slack.com/t/kzrb/shared_invite/zt-1f4tcvoud-w5whpsFrRpFyFHisVpyMCA) から登録ください。
     * Slack はイベントを補助するものであり、本 meetup への参加に Slack 登録は必須ではありません。
 
 

--- a/_posts/105/index.md
+++ b/_posts/105/index.md
@@ -42,7 +42,7 @@ Kanazawa.rbの意識高いもくもく会には以下のような特徴があり
 * Zoom と同時にテキストチャットルームも活用します。
     * 発表に対するフィードバックや URL の共有等に利用します。
     * Slack というサービスの [Kanazawa.rb 用ワークスペース内](https://kzrb.slack.com/) にある `#meetup105` チャネルにご参加ください。
-    * アカウントの新規発行をご希望の方は [こちら](https://kzrb-slackin.herokuapp.com/) から登録ください。
+    * アカウントの新規発行をご希望の方は [こちら](https://join.slack.com/t/kzrb/shared_invite/zt-1f4tcvoud-w5whpsFrRpFyFHisVpyMCA) から登録ください。
     * Slack はイベントを補助するものであり、本 meetup への参加に Slack 登録は必須ではありません。
 
 

--- a/_posts/106/index.md
+++ b/_posts/106/index.md
@@ -42,7 +42,7 @@ Kanazawa.rbの意識高いもくもく会には以下のような特徴があり
 * Zoom と同時にテキストチャットルームも活用します。
     * 発表に対するフィードバックや URL の共有等に利用します。
     * Slack というサービスの [Kanazawa.rb 用ワークスペース内](https://kzrb.slack.com/) にある `#meetup106` チャネルにご参加ください。
-    * アカウントの新規発行をご希望の方は [こちら](https://kzrb-slackin.herokuapp.com/) から登録ください。
+    * アカウントの新規発行をご希望の方は [こちら](https://join.slack.com/t/kzrb/shared_invite/zt-1f4tcvoud-w5whpsFrRpFyFHisVpyMCA) から登録ください。
     * Slack はイベントを補助するものであり、本 meetup への参加に Slack 登録は必須ではありません。
 
 

--- a/_posts/107/index.md
+++ b/_posts/107/index.md
@@ -42,7 +42,7 @@ published: true
 * Zoom と同時にテキストチャットルームも活用します。
     * 発表に対するフィードバックや URL の共有等に利用します。
     * Slack というサービスの [Kanazawa.rb 用ワークスペース内](https://kzrb.slack.com/) にある `#meetup107` チャネルにご参加ください。
-    * アカウントの新規発行をご希望の方は [こちら](https://kzrb-slackin.herokuapp.com/) から登録ください。
+    * アカウントの新規発行をご希望の方は [こちら](https://join.slack.com/t/kzrb/shared_invite/zt-1f4tcvoud-w5whpsFrRpFyFHisVpyMCA) から登録ください。
     * Slack はイベントを補助するものであり、本 meetup への参加に Slack 登録は必須ではありません。
 
 

--- a/_posts/108/index.md
+++ b/_posts/108/index.md
@@ -64,7 +64,7 @@ Tシャツはいくつかのカラーバリエーションがあり、サイズ�
 * Zoom と同時にテキストチャットルームも活用します。
     * 発表に対するフィードバックや URL の共有等に利用します。
     * Slack というサービスの [Kanazawa.rb 用ワークスペース内](https://kzrb.slack.com/) にある `#meetup108` チャネルにご参加ください。
-    * アカウントの新規発行をご希望の方は [こちら](https://kzrb-slackin.herokuapp.com/) から登録ください。
+    * アカウントの新規発行をご希望の方は [こちら](https://join.slack.com/t/kzrb/shared_invite/zt-1f4tcvoud-w5whpsFrRpFyFHisVpyMCA) から登録ください。
     * Slack はイベントを補助するものであり、本 meetup への参加に Slack 登録は必須ではありません。
 
 

--- a/_posts/109/index.md
+++ b/_posts/109/index.md
@@ -42,7 +42,7 @@ Kanazawa.rbの意識高いもくもく会には以下のような特徴があり
 * Zoom と同時にテキストチャットルームも活用します。
     * 発表に対するフィードバックや URL の共有等に利用します。
     * Slack というサービスの [Kanazawa.rb 用ワークスペース内](https://kzrb.slack.com/) にある `#meetup109` チャネルにご参加ください。
-    * アカウントの新規発行をご希望の方は [こちら](https://kzrb-slackin.herokuapp.com/) から登録ください。
+    * アカウントの新規発行をご希望の方は [こちら](https://join.slack.com/t/kzrb/shared_invite/zt-1f4tcvoud-w5whpsFrRpFyFHisVpyMCA) から登録ください。
     * Slack はイベントを補助するものであり、本 meetup への参加に Slack 登録は必須ではありません。
 
 

--- a/_posts/110/index.md
+++ b/_posts/110/index.md
@@ -42,7 +42,7 @@ published: true
 * Zoom と同時にテキストチャットルームも活用します。
     * 発表に対するフィードバックや URL の共有等に利用します。
     * Slack というサービスの [Kanazawa.rb 用ワークスペース内](https://kzrb.slack.com/) にある `#meetup110` チャネルにご参加ください。
-    * アカウントの新規発行をご希望の方は [こちら](https://kzrb-slackin.herokuapp.com/) から登録ください。
+    * アカウントの新規発行をご希望の方は [こちら](https://join.slack.com/t/kzrb/shared_invite/zt-1f4tcvoud-w5whpsFrRpFyFHisVpyMCA) から登録ください。
     * Slack はイベントを補助するものであり、本 meetup への参加に Slack 登録は必須ではありません。
 
 

--- a/_posts/111/index.md
+++ b/_posts/111/index.md
@@ -42,7 +42,7 @@ Kanazawa.rbの意識高いもくもく会には以下のような特徴があり
 * Zoom と同時にテキストチャットルームも活用します。
     * 発表に対するフィードバックや URL の共有等に利用します。
     * Slack というサービスの [Kanazawa.rb 用ワークスペース内](https://kzrb.slack.com/) にある `#meetup111` チャネルにご参加ください。
-    * アカウントの新規発行をご希望の方は [こちら](https://kzrb-slackin.herokuapp.com/) から登録ください。
+    * アカウントの新規発行をご希望の方は [こちら](https://join.slack.com/t/kzrb/shared_invite/zt-1f4tcvoud-w5whpsFrRpFyFHisVpyMCA) から登録ください。
     * Slack はイベントを補助するものであり、本 meetup への参加に Slack 登録は必須ではありません。
 
 

--- a/_posts/112/index.md
+++ b/_posts/112/index.md
@@ -45,7 +45,7 @@ Twitter 上で表明してもらえると助かります。
 * Zoom と同時にテキストチャットルームも活用します。
     * 発表に対するフィードバックや URL の共有等に利用します。
     * Slack というサービスの [Kanazawa.rb 用ワークスペース内](https://kzrb.slack.com/) にある `#meetup112` チャネルにご参加ください。
-    * アカウントの新規発行をご希望の方は [こちら](https://kzrb-slackin.herokuapp.com/) から登録ください。
+    * アカウントの新規発行をご希望の方は [こちら](https://join.slack.com/t/kzrb/shared_invite/zt-1f4tcvoud-w5whpsFrRpFyFHisVpyMCA) から登録ください。
     * Slack はイベントを補助するものであり、本 meetup への参加に Slack 登録は必須ではありません。
 
 

--- a/_posts/113/index.md
+++ b/_posts/113/index.md
@@ -42,7 +42,7 @@ Kanazawa.rbの意識高いもくもく会には以下のような特徴があり
 * Zoom と同時にテキストチャットルームも活用します。
     * 発表に対するフィードバックや URL の共有等に利用します。
     * Slack というサービスの [Kanazawa.rb 用ワークスペース内](https://kzrb.slack.com/) にある `#meetup113` チャネルにご参加ください。
-    * アカウントの新規発行をご希望の方は [こちら](https://kzrb-slackin.herokuapp.com/) から登録ください。
+    * アカウントの新規発行をご希望の方は [こちら](https://join.slack.com/t/kzrb/shared_invite/zt-1f4tcvoud-w5whpsFrRpFyFHisVpyMCA) から登録ください。
     * Slack はイベントを補助するものであり、本 meetup への参加に Slack 登録は必須ではありません。
 
 

--- a/_posts/114/index.md
+++ b/_posts/114/index.md
@@ -42,7 +42,7 @@ Kanazawa.rbの意識高いもくもく会には以下のような特徴があり
 * Zoom と同時にテキストチャットルームも活用します。
     * 発表に対するフィードバックや URL の共有等に利用します。
     * Slack というサービスの [Kanazawa.rb 用ワークスペース内](https://kzrb.slack.com/) にある `#meetup114` チャネルにご参加ください。
-    * アカウントの新規発行をご希望の方は [こちら](https://kzrb-slackin.herokuapp.com/) から登録ください。
+    * アカウントの新規発行をご希望の方は [こちら](https://join.slack.com/t/kzrb/shared_invite/zt-1f4tcvoud-w5whpsFrRpFyFHisVpyMCA) から登録ください。
     * Slack はイベントを補助するものであり、本 meetup への参加に Slack 登録は必須ではありません。
 
 

--- a/_posts/115/index.md
+++ b/_posts/115/index.md
@@ -42,7 +42,7 @@ Kanazawa.rbの意識高いもくもく会には以下のような特徴があり
 * Zoom と同時にテキストチャットルームも活用します。
     * 発表に対するフィードバックや URL の共有等に利用します。
     * Slack というサービスの [Kanazawa.rb 用ワークスペース内](https://kzrb.slack.com/) にある `#meetup115` チャネルにご参加ください。
-    * アカウントの新規発行をご希望の方は [こちら](https://kzrb-slackin.herokuapp.com/) から登録ください。
+    * アカウントの新規発行をご希望の方は [こちら](https://join.slack.com/t/kzrb/shared_invite/zt-1f4tcvoud-w5whpsFrRpFyFHisVpyMCA) から登録ください。
     * Slack はイベントを補助するものであり、本 meetup への参加に Slack 登録は必須ではありません。
 
 

--- a/_posts/116/index.md
+++ b/_posts/116/index.md
@@ -45,7 +45,7 @@ Rails初心者の方も、使っているけど7はまだなんだよねーと�
 * Zoom と同時にテキストチャットルームも活用します。
     * 発表に対するフィードバックや URL の共有等に利用します。
     * Slack というサービスの [Kanazawa.rb 用ワークスペース内](https://kzrb.slack.com/) にある `#meetup116` チャネルにご参加ください。
-    * アカウントの新規発行をご希望の方は [こちら](https://kzrb-slackin.herokuapp.com/) から登録ください。
+    * アカウントの新規発行をご希望の方は [こちら](https://join.slack.com/t/kzrb/shared_invite/zt-1f4tcvoud-w5whpsFrRpFyFHisVpyMCA) から登録ください。
     * Slack はイベントを補助するものであり、本 meetup への参加に Slack 登録は必須ではありません。
 
 

--- a/_posts/118/index.md
+++ b/_posts/118/index.md
@@ -42,7 +42,7 @@ Kanazawa.rbの意識高いもくもく会には以下のような特徴があり
 * Zoom と同時にテキストチャットルームも活用します。
     * 発表に対するフィードバックや URL の共有等に利用します。
     * Slack というサービスの [Kanazawa.rb 用ワークスペース内](https://kzrb.slack.com/) にある `#meetup118` チャネルにご参加ください。
-    * アカウントの新規発行をご希望の方は [こちら](https://kzrb-slackin.herokuapp.com/) から登録ください。
+    * アカウントの新規発行をご希望の方は [こちら](https://join.slack.com/t/kzrb/shared_invite/zt-1f4tcvoud-w5whpsFrRpFyFHisVpyMCA) から登録ください。
     * Slack はイベントを補助するものであり、本 meetup への参加に Slack 登録は必須ではありません。
 
 

--- a/_posts/119/index.md
+++ b/_posts/119/index.md
@@ -41,7 +41,7 @@ Kanazawa.rbの意識高いもくもく会には以下のような特徴があり
 * Gather と同時にテキストチャットルームも活用します。
     * 発表に対するフィードバックや URL の共有等に利用します。
     * Slack というサービスの [Kanazawa.rb 用ワークスペース内](https://kzrb.slack.com/) にある `#meetup119` チャネルにご参加ください。
-    * アカウントの新規発行をご希望の方は [こちら](https://kzrb-slackin.herokuapp.com/) から登録ください。
+    * アカウントの新規発行をご希望の方は [こちら](https://join.slack.com/t/kzrb/shared_invite/zt-1f4tcvoud-w5whpsFrRpFyFHisVpyMCA) から登録ください。
     * Slack はイベントを補助するものであり、本 meetup への参加に Slack 登録は必須ではありません。
 
 

--- a/_posts/120/index.md
+++ b/_posts/120/index.md
@@ -67,7 +67,7 @@ Tシャツはいくつかのカラーバリエーションがあり、サイズ�
 * テキストチャットルームも活用します。
     * 発表に対するフィードバックや URL の共有等に利用します。
     * Slack というサービスの [kanazawa.rb 用ワークスペース内](https://kzrb.slack.com/) にある `#meetup120` チャネルにご参加ください。
-    * アカウントの新規発行をご希望の方は [こちら](https://kzrb-slackin.herokuapp.com/) から登録ください。
+    * アカウントの新規発行をご希望の方は [こちら](https://join.slack.com/t/kzrb/shared_invite/zt-1f4tcvoud-w5whpsFrRpFyFHisVpyMCA) から登録ください。
     * Slack はイベントを補助するものであり、本 meetup への参加に Slack 登録は必須ではありません。
 
 ## ざっくりタイムテーブル

--- a/_posts/121/index.md
+++ b/_posts/121/index.md
@@ -47,7 +47,7 @@ Kanazawa.rbの意識高いもくもく会には以下のような特徴があり
 * Gather と同時にテキストチャットルームも活用します。
     * 発表に対するフィードバックや URL の共有等に利用します。
     * Slack というサービスの [Kanazawa.rb 用ワークスペース内](https://kzrb.slack.com/) にある `#meetup121` チャネルにご参加ください。
-    * アカウントの新規発行をご希望の方は [こちら](https://kzrb-slackin.herokuapp.com/) から登録ください。
+    * アカウントの新規発行をご希望の方は [こちら](https://join.slack.com/t/kzrb/shared_invite/zt-1f4tcvoud-w5whpsFrRpFyFHisVpyMCA) から登録ください。
     * Slack はイベントを補助するものであり、本 meetup への参加に Slack 登録は必須ではありません。
 
 

--- a/_posts/50/report.md
+++ b/_posts/50/report.md
@@ -18,7 +18,7 @@ published: true
 * いざわさんの LT スタート。蛍光灯、ちゃんと選んでる？ってはなし [写真](https://www.instagram.com/p/BLkm-0DBC8N/)
 * わたなべさんの LT スタート。QR コードのバルク生成の話。 [写真](https://www.instagram.com/p/BLkoAmUBaro/)
 * むらのさんの LT スタート。slack に、誰でも参加できるようにする仕組みについて。slackin を heroku で動かしてる。 [写真](https://www.instagram.com/p/BLkqbOLhVj-/)
-  + Join kanazawa.rb on Slack! [kzrb-slackin.herokuapp.com](https://kzrb-slackin.herokuapp.com/)
+  + Join kanazawa.rb on Slack! [kzrb-slackin.herokuapp.com](https://join.slack.com/t/kzrb/shared_invite/zt-1f4tcvoud-w5whpsFrRpFyFHisVpyMCA)
 * じとめさんの基板話を聞いてる [写真](https://www.instagram.com/p/BLkuvv2hNr_/)
 * Kanazawa.rb meetup 50 done!! [写真](https://www.instagram.com/p/BLk3_JvBwXr/)
 

--- a/_posts/93/index.md
+++ b/_posts/93/index.md
@@ -34,7 +34,7 @@ LT 大会 - オンライン
 * Zoom と同時にテキストチャットルームも活用します。
     * 発表に対するフィードバックや URL の共有等に利用します。
     * Slack というサービスの [Kanazawa.rb 用ワークスペース内](https://kzrb.slack.com/) にある `#meetup93` チャネルにご参加ください。
-    * アカウントの新規発行をご希望の方は [こちら](https://kzrb-slackin.herokuapp.com/) から登録ください。
+    * アカウントの新規発行をご希望の方は [こちら](https://join.slack.com/t/kzrb/shared_invite/zt-1f4tcvoud-w5whpsFrRpFyFHisVpyMCA) から登録ください。
     * Slack はイベントを補助するものであり、本 meetup への参加に Slack 登録は必須ではありません。
 
 また、参加される方は、どんな内容を話すかを以下いずれかの方法で共有いただけますと助かります。

--- a/_posts/94/index.md
+++ b/_posts/94/index.md
@@ -31,7 +31,7 @@ published: true
 * Zoom と同時にテキストチャットルームも活用します。
     * 発表に対するフィードバックや URL の共有等に利用します。
     * Slack というサービスの [Kanazawa.rb 用ワークスペース内](https://kzrb.slack.com/) にある `#meetup94` チャネルにご参加ください。
-    * アカウントの新規発行をご希望の方は [こちら](https://kzrb-slackin.herokuapp.com/) から登録ください。
+    * アカウントの新規発行をご希望の方は [こちら](https://join.slack.com/t/kzrb/shared_invite/zt-1f4tcvoud-w5whpsFrRpFyFHisVpyMCA) から登録ください。
     * Slack はイベントを補助するものであり、本 meetup への参加に Slack 登録は必須ではありません。
 
 Kanazawa.rbの意識高いもくもく会には以下のような特徴があります。

--- a/_posts/95/index.md
+++ b/_posts/95/index.md
@@ -31,7 +31,7 @@ published: true
 * Zoom と同時にテキストチャットルームも活用します。
     * 発表に対するフィードバックや URL の共有等に利用します。
     * Slack というサービスの [Kanazawa.rb 用ワークスペース内](https://kzrb.slack.com/) にある `#meetup95` チャネルにご参加ください。
-    * アカウントの新規発行をご希望の方は [こちら](https://kzrb-slackin.herokuapp.com/) から登録ください。
+    * アカウントの新規発行をご希望の方は [こちら](https://join.slack.com/t/kzrb/shared_invite/zt-1f4tcvoud-w5whpsFrRpFyFHisVpyMCA) から登録ください。
     * Slack はイベントを補助するものであり、本 meetup への参加に Slack 登録は必須ではありません。
 
 Kanazawa.rbの意識高いもくもく会には以下のような特徴があります。

--- a/_posts/96/index.md
+++ b/_posts/96/index.md
@@ -47,7 +47,7 @@ published: true
 * Zoom と同時にテキストチャットルームも活用します。
     * 発表に対するフィードバックや URL の共有等に利用します。
     * Slack というサービスの [Kanazawa.rb 用ワークスペース内](https://kzrb.slack.com/) にある `#meetup96` チャネルにご参加ください。
-    * アカウントの新規発行をご希望の方は [こちら](https://kzrb-slackin.herokuapp.com/) から登録ください。
+    * アカウントの新規発行をご希望の方は [こちら](https://join.slack.com/t/kzrb/shared_invite/zt-1f4tcvoud-w5whpsFrRpFyFHisVpyMCA) から登録ください。
     * Slack はイベントを補助するものであり、本 meetup への参加に Slack 登録は必須ではありません。
 
 

--- a/_posts/97/index.md
+++ b/_posts/97/index.md
@@ -42,7 +42,7 @@ Kanazawa.rbの意識高いもくもく会には以下のような特徴があり
 * Zoom と同時にテキストチャットルームも活用します。
     * 発表に対するフィードバックや URL の共有等に利用します。
     * Slack というサービスの [Kanazawa.rb 用ワークスペース内](https://kzrb.slack.com/) にある `#meetup97` チャネルにご参加ください。
-    * アカウントの新規発行をご希望の方は [こちら](https://kzrb-slackin.herokuapp.com/) から登録ください。
+    * アカウントの新規発行をご希望の方は [こちら](https://join.slack.com/t/kzrb/shared_invite/zt-1f4tcvoud-w5whpsFrRpFyFHisVpyMCA) から登録ください。
     * Slack はイベントを補助するものであり、本 meetup への参加に Slack 登録は必須ではありません。
 
 

--- a/_posts/98/index.md
+++ b/_posts/98/index.md
@@ -41,7 +41,7 @@ published: true
 * Zoom と同時にテキストチャットルームも活用します。
     * 発表に対するフィードバックや URL の共有等に利用します。
     * Slack というサービスの [Kanazawa.rb 用ワークスペース内](https://kzrb.slack.com/) にある `#meetup98` チャネルにご参加ください。
-    * アカウントの新規発行をご希望の方は [こちら](https://kzrb-slackin.herokuapp.com/) から登録ください。
+    * アカウントの新規発行をご希望の方は [こちら](https://join.slack.com/t/kzrb/shared_invite/zt-1f4tcvoud-w5whpsFrRpFyFHisVpyMCA) から登録ください。
     * Slack はイベントを補助するものであり、本 meetup への参加に Slack 登録は必須ではありません。
 
 ## ざっくりタイムテーブル

--- a/_posts/99/index.md
+++ b/_posts/99/index.md
@@ -42,7 +42,7 @@ Kanazawa.rbの意識高いもくもく会には以下のような特徴があり
 * Zoom と同時にテキストチャットルームも活用します。
     * 発表に対するフィードバックや URL の共有等に利用します。
     * Slack というサービスの [Kanazawa.rb 用ワークスペース内](https://kzrb.slack.com/) にある `#meetup99` チャネルにご参加ください。
-    * アカウントの新規発行をご希望の方は [こちら](https://kzrb-slackin.herokuapp.com/) から登録ください。
+    * アカウントの新規発行をご希望の方は [こちら](https://join.slack.com/t/kzrb/shared_invite/zt-1f4tcvoud-w5whpsFrRpFyFHisVpyMCA) から登録ください。
     * Slack はイベントを補助するものであり、本 meetup への参加に Slack 登録は必須ではありません。
 
 


### PR DESCRIPTION
git-gsub を使って以下のコマンドで置き換えました。
```console
$ gem install git-gsub --no-document
$ git gsub 'https://kzrb-slackin.herokuapp.com/' 'https://join.slack.com/t/kzrb/shared_invite/zt-1f4tcvoud-w5whpsFrRpFyFHisVpyMCA' _posts/

```
