### PR TITLE
just-the-docs.rc2 を適用する

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -85,8 +85,8 @@ nav_sort: case_sensitive # Capital letters sorted before lowercase
 
 # External navigation links
 nav_external_links:
-  - title: Just the Docs on GitHub
-    url: https://github.com/just-the-docs/just-the-docs
+  - title: Kanazawa.rb の Doorkeeper
+    url: https://kzrb.doorkeeper.jp/
 
 # Footer content
 # appears at the bottom of every page's main content

--- a/_config.yml
+++ b/_config.yml
@@ -14,6 +14,7 @@ exclude:
   - "Gemfile.lock"
   - "package.json"
   - "package-lock.json"
+  - "script/"
   - "LICENSE.txt"
   - "lib/"
   - "bin/"
@@ -21,8 +22,9 @@ exclude:
   - "Rakefile"
   - "docs/tests/"
   - "*.tags"
-  - '.jekyll-cache'
-  - 'post/.jekyll-cache'
+  - ".jekyll-cache"
+  - "post/.jekyll-cache"
+  - "vendor"
 
 theme: just-the-docs
 
@@ -56,6 +58,16 @@ search:
   # Supports true or false (default)
   button: false
 
+# To disable support for mermaid diagrams (https://mermaid-js.github.io/mermaid/),
+# comment out the `mermaid` and `version` keys below
+# By default, consuming the theme as a gem leaves mermaid disabled; it is opt-in
+mermaid:
+  # Version of mermaid library
+  # Pick an available version from https://cdn.jsdelivr.net/npm/mermaid/
+  version: "9.1.6"
+  # Put any additional configuration, such as setting the theme, in _includes/mermaid_config.js
+  # See also docs/ui-components/code
+
 # Enable or disable heading anchors
 heading_anchors: true
 
@@ -70,6 +82,11 @@ aux_links_new_tab: false
 # Sort order for navigation links
 # nav_sort: case_insensitive # default, equivalent to nil
 nav_sort: case_sensitive # Capital letters sorted before lowercase
+
+# External navigation links
+nav_external_links:
+  - title: Just the Docs on GitHub
+    url: https://github.com/just-the-docs/just-the-docs
 
 # Footer content
 # appears at the bottom of every page's main content
@@ -96,6 +113,23 @@ last_edit_time_format: "%F" # uses ruby's time format: https://ruby-doc.org/stdl
 
 # Color scheme currently only supports "dark", "light"/nil (default), or a custom scheme that you define
 color_scheme: nil
+
+callouts_level: quiet # or loud
+callouts:
+  highlight:
+    color: yellow
+  important:
+    title: Important
+    color: blue
+  new:
+    title: New
+    color: green
+  note:
+    title: Note
+    color: purple
+  warning:
+    title: Warning
+    color: red
 
 # Google Analytics Tracking (optional)
 # e.g, UA-1234567-89

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,95 +1,117 @@
-<ul class="nav-list">
-  {%- assign titled_pages = include.pages
-        | where_exp:"item", "item.title != nil" -%}
-
-  {%- comment -%}
-    The values of `title` and `nav_order` can be numbers or strings.
-    Jekyll gives build failures when sorting on mixtures of different types,
-    so numbers and strings need to be sorted separately.
-
-    Here, numbers are sorted by their values, and come before all strings.
-    An omitted `nav_order` value is equivalent to the page's `title` value
-    (except that a numerical `title` value is treated as a string).
-
-    The case-sensitivity of string sorting is determined by `site.nav_sort`.
-  {%- endcomment -%}
+{%- comment -%}
+  Pages with no `title` are implicitly excluded from the navigation.
   
-  {%- assign string_ordered_pages = titled_pages
-        | where_exp:"item", "item.nav_order == nil" -%}
-  {%- assign nav_ordered_pages = titled_pages
-        | where_exp:"item", "item.nav_order != nil"  -%}
+  The values of `title` and `nav_order` can be numbers or strings.
+  Jekyll gives build failures when sorting on mixtures of different types,
+  so numbers and strings need to be sorted separately.
 
-  {%- comment -%}
-    The nav_ordered_pages have to be added to number_ordered_pages and
-    string_ordered_pages, depending on the nav_order value.
-    The first character of the jsonify result is `"` only for strings.
-  {%- endcomment -%}
-  {%- assign nav_ordered_groups = nav_ordered_pages
-        | group_by_exp:"item", "item.nav_order | jsonify | slice: 0" -%}
-  {%- assign number_ordered_pages = "" | split:"X" -%}
-  {%- for group in nav_ordered_groups -%}
-    {%- if group.name == '"' -%}
-      {%- assign string_ordered_pages = string_ordered_pages | concat: group.items -%}
-    {%- else -%}
-      {%- assign number_ordered_pages = number_ordered_pages | concat: group.items -%}
-    {%- endif -%}
-  {%- endfor -%}
+  Here, numbers are sorted by their values, and come before all strings.
+  An omitted `nav_order` value is equivalent to the page's `title` value
+  (except that a numerical `title` value is treated as a string).
+
+  The case-sensitivity of string sorting is determined by `site.nav_sort`.
+{%- endcomment -%}
+
+{%- assign titled_pages = include.pages
+      | where_exp: "item", "item.title != nil" -%}
+
+{%- assign string_ordered_pages = titled_pages
+      | where_exp: "item", "item.nav_order == nil" -%}
+{%- assign nav_ordered_pages = titled_pages
+      | where_exp: "item", "item.nav_order != nil" -%}
+
+{%- comment -%}
+  Add the nav-ordered pages to the number-ordered pages or the string-ordered pages,
+  depending on their `nav_order` value.
   
-  {%- assign sorted_number_ordered_pages = number_ordered_pages | sort:"nav_order" -%}
-  
-  {%- comment -%}
-    The string_ordered_pages have to be sorted by nav_order, and otherwise title
-    (where appending the empty string to a numeric title converts it to a string).
-    After grouping them by those values, the groups are sorted, then the items
-    of each group are concatenated.
-  {%- endcomment -%}
-  {%- assign string_ordered_groups = string_ordered_pages
-        | group_by_exp:"item", "item.nav_order | default: item.title | append:''" -%}
-  {%- if site.nav_sort == 'case_insensitive' -%}
-    {%- assign sorted_string_ordered_groups = string_ordered_groups | sort_natural:"name" -%}
+  The first character of the `jsonify` result is `"` only for strings.
+{%- endcomment -%}
+
+{%- assign nav_ordered_groups = nav_ordered_pages
+      | group_by_exp: "item", "item.nav_order | jsonify | slice: 0" -%}
+
+{%- assign number_ordered_pages = "" | split: "" -%}
+{%- for group in nav_ordered_groups -%}
+  {%- if group.name == '"' -%}
+    {%- assign string_ordered_pages = string_ordered_pages | concat: group.items -%}
   {%- else -%}
-    {%- assign sorted_string_ordered_groups = string_ordered_groups | sort:"name" -%}
+    {%- assign number_ordered_pages = number_ordered_pages | concat: group.items -%}
   {%- endif -%}
-  {%- assign sorted_string_ordered_pages = "" | split:"X" -%}
-  {%- for group in sorted_string_ordered_groups -%}
-    {%- assign sorted_string_ordered_pages = sorted_string_ordered_pages | concat: group.items -%}
-  {%- endfor -%}
+{%- endfor -%}
 
-  {%- assign pages_list = sorted_number_ordered_pages | concat: sorted_string_ordered_pages -%}
+{%- assign sorted_number_ordered_groups = number_ordered_pages
+      | sort: "nav_order" | group_by: "nav_order" -%}
+
+{%- comment -%}
+  Group the string-ordered pages by `nav_order`, if non-nil, and otherwise `title`
+  (but appending the empty string to a numeric title to convert it to a string).
   
-  {%- for node in pages_list -%}
+  Then sort the groups according to the site setting for case (in)sensitivity.
+{%- endcomment -%}
+
+{%- assign string_ordered_groups = string_ordered_pages
+      | group_by_exp:"item", "item.nav_order | default: item.title | append: '' " -%}
+
+{%- if site.nav_sort == 'case_insensitive' -%}
+  {%- assign sorted_string_ordered_groups = string_ordered_groups
+        | sort_natural: "name" -%}
+{%- else -%}
+  {%- assign sorted_string_ordered_groups = string_ordered_groups
+        | sort:"name" -%}
+{%- endif -%}
+
+{%- assign groups_list = sorted_number_ordered_groups
+      | concat: sorted_string_ordered_groups -%}
+
+<ul class="nav-list">
+  {%- for node_group in groups_list -%} 
+  {%- for node in node_group.items -%}
     {%- if node.parent == nil -%}
       {%- unless node.nav_exclude -%}
       <li class="nav-list-item{% if page.collection == include.key and page.url == node.url or page.parent == node.title or page.grand_parent == node.title %} active{% endif %}">
         {%- if node.has_children -%}
-          <a href="#" class="nav-list-expander"><svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg></a>
+          <a href="#" class="nav-list-expander" aria-label="toggle links in {{ node.title }} category">
+            <svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg>
+          </a>
         {%- endif -%}
         <a href="{{ node.url | relative_url }}" class="nav-list-link{% if page.url == node.url %} active{% endif %}">{{ node.title }}</a>
         {%- if node.has_children -%}
+          {%- assign children_list = "" | split: "" -%}
+          {%- for parent_group in groups_list -%}
+            {%- assign children_list = children_list 
+                  | concat: parent_group.items
+                  | where: "parent", node.title
+                  | where_exp:"item", "item.grand_parent == nil" -%}
+          {%- endfor -%}
           {%- if node.child_nav_order == 'desc' -%}
-            {%- assign children_list = pages_list | where: "parent", node.title | where_exp:"item", "item.grand_parent == nil" | reverse -%}
-          {%- else -%}
-            {%- assign children_list = pages_list | where: "parent", node.title | where_exp:"item", "item.grand_parent == nil" -%}
+            {%- assign children_list = children_list | reverse -%}
           {%- endif -%}
           <ul class="nav-list ">
           {%- for child in children_list -%}
             {%- unless child.nav_exclude -%}
             <li class="nav-list-item {% if page.url == child.url or page.parent == child.title %} active{% endif %}">
               {%- if child.has_children -%}
-                <a href="#" class="nav-list-expander"><svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg></a>
+                <a href="#" class="nav-list-expander" aria-label="toggle links in {{ child.title }} category">
+                  <svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg>
+                </a>
               {%- endif -%}
               <a href="{{ child.url | relative_url }}" class="nav-list-link{% if page.url == child.url %} active{% endif %}">{{ child.title }}</a>
               {%- if child.has_children -%}
+                {%- assign grandchildren_list = "" | split: "" -%}
+                {%- for grandparent_group in groups_list -%}
+                  {%- assign grandchildren_list = grandchildren_list
+                        | concat: grandparent_group.items
+                        | where: "parent", child.title
+                        | where: "grand_parent", node.title -%}
+                {%- endfor -%}
                 {%- if node.child_nav_order == 'desc' -%}
-                {%- assign grand_children_list = pages_list | where: "parent", child.title | where: "grand_parent", node.title | reverse -%}
-                {%- else -%}
-                {%- assign grand_children_list = pages_list | where: "parent", child.title | where: "grand_parent", node.title -%}
+                  {%- assign grandchildren_list = grandchildren_list | reverse -%}
                 {%- endif -%}
                 <ul class="nav-list">
-                {%- for grand_child in grand_children_list -%}
-                  {%- unless grand_child.nav_exclude -%}
-                  <li class="nav-list-item {% if page.url == grand_child.url %} active{% endif %}">
-                    <a href="{{ grand_child.url | relative_url }}" class="nav-list-link{% if page.url == grand_child.url %} active{% endif %}">{{ grand_child.title }}</a>
+                {%- for grandchild in grandchildren_list -%}
+                  {%- unless grandchild.nav_exclude -%}
+                  <li class="nav-list-item {% if page.url == grandchild.url %} active{% endif %}">
+                    <a href="{{ grandchild.url | relative_url }}" class="nav-list-link{% if page.url == grand_child.url %} active{% endif %}">{{ grandchild.title }}</a>
                   </li>
                   {%- endunless -%}
                 {%- endfor -%}
@@ -104,6 +126,7 @@
       {%- endunless -%}
     {%- endif -%}
   {%- endfor -%}
+  {%- endfor -%}
   {%- assign nav_external_links = site.nav_external_links -%}
   {%- for node in nav_external_links -%}
     <li class="nav-list-item external">
@@ -117,16 +140,28 @@
 
 {%- if page.collection == include.key -%}
 
-  {%- for node in pages_list -%}
+  {%- for node_group in groups_list -%}
+  {%- for node in node_group.items -%}
     {%- if node.parent == nil -%}
-      {%- if page.grand_parent == node.title or page.parent == node.title and page.grand_parent == nil -%}
+      {%- if page.grand_parent == node.title 
+              or page.parent == node.title
+              and page.grand_parent == nil -%}
         {%- assign first_level_url = node.url | relative_url -%}
       {%- endif -%}
       {%- if node.has_children -%}
-        {%- assign children_list = pages_list | where: "parent", node.title -%}
+        {%- assign children_list = "" | split: "" -%}
+        {%- for parent_group in groups_list -%}
+          {%- assign children_list = children_list | concat: 
+                parent_group.items | where: "parent", node.title -%}
+        {%- endfor -%}
+        {%- if node.child_nav_order == 'desc' -%}
+          {%- assign children_list = children_list | reverse -%}
+        {%- endif -%}
         {%- for child in children_list -%}
           {%- if child.has_children -%}
-            {%- if page.url == child.url or page.parent == child.title and page.grand_parent == child.parent -%}
+            {%- if page.url == child.url
+                    or page.parent == child.title
+                    and page.grand_parent == child.parent -%}
               {%- assign second_level_url = child.url | relative_url -%}
             {%- endif -%}
           {%- endif -%}
@@ -134,9 +169,19 @@
       {%- endif -%}
     {%- endif -%}
   {%- endfor -%}
+  {%- endfor -%}
 
   {% if page.has_children == true and page.has_toc != false %}
-    {%- assign toc_list = pages_list | where: "parent", page.title | where: "grand_parent", page.parent -%}
+    {%- assign toc_list = "" | split: "" -%}
+    {%- for parent_group in groups_list -%}
+      {%- assign toc_list = toc_list
+            | concat: parent_group.items
+            | where: "parent", page.title
+            | where: "grand_parent", page.parent -%}
+    {%- endfor -%}
+    {%- if node.child_nav_order == 'desc' -%}
+      {%- assign toc_list = toc_list | reverse -%}
+    {%- endif -%}
   {%- endif -%}
 
 {%- endif -%}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,6 +7,7 @@ layout: table_wrappers
 <html lang="{{ site.lang | default: 'en-US' }}">
 {% include head.html %}
 <body>
+  <a class="skip-to-main" href="#main-content">Skip to main content</a>
   <svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
     <symbol id="svg-link" viewBox="0 0 24 24">
       <title>Link</title>
@@ -181,9 +182,9 @@ layout: table_wrappers
 
             {% if site.last_edit_timestamp or site.gh_edit_link %}
               <div class="d-flex mt-2">
-                {% if site.last_edit_timestamp and site.last_edit_time_format %}
+                {% if site.last_edit_timestamp and site.last_edit_time_format and page.last_modified_date %}
                   <p class="text-small text-grey-dk-000 mb-0 mr-2">
-                    Page last modified: <span class="d-inline-block">{{ "now" | date: site.last_edit_time_format }}</span>.
+                    Page last modified: <span class="d-inline-block">{{ page.last_modified_date | date: site.last_edit_time_format }}</span>.
                   </p>
                 {% endif %}
                 {% if

--- a/_sass/code.scss
+++ b/_sass/code.scss
@@ -48,7 +48,7 @@ a:visited code {
 
 // ```[LANG]...```
 div.highlighter-rouge,
-div.listingblock {
+div.listingblock > div.content {
   padding: $sp-3;
   margin-top: 0;
   margin-bottom: $sp-3;
@@ -119,7 +119,8 @@ figure.highlight {
 // Code examples (rendered)
 //
 
-.code-example {
+.code-example,
+.listingblock > .title {
   padding: $sp-3;
   margin-bottom: $sp-3;
   overflow: auto;
@@ -128,6 +129,7 @@ figure.highlight {
 
   + .highlighter-rouge,
   + .sectionbody .listingblock,
+  + .content,
   + figure.highlight {
     position: relative;
     margin-top: -$sp-4;

--- a/_sass/modules.scss
+++ b/_sass/modules.scss
@@ -14,3 +14,4 @@
 @import "./code";
 @import "./utilities/utilities";
 @import "./print";
+@import "./skiptomain";

--- a/_sass/skiptomain.scss
+++ b/_sass/skiptomain.scss
@@ -1,0 +1,30 @@
+// Skipnav
+// Skip to main content
+
+a.skip-to-main {
+  left: -999px;
+  position: absolute;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  z-index: -999;
+}
+
+a.skip-to-main:focus,
+a.skip-to-main:active {
+  color: $link-color;
+  background-color: $body-background-color;
+  left: auto;
+  top: auto;
+  width: 30%;
+  height: auto;
+  overflow: auto;
+  margin: 10px 35%;
+  padding: 5px;
+  border-radius: 15px;
+  border: 4px solid $btn-primary-color;
+  text-align: center;
+  font-size: 1.2em;
+  z-index: 999;
+}

--- a/assets/js/zzzz-search-data.json
+++ b/assets/js/zzzz-search-data.json
@@ -3,7 +3,7 @@ permalink: /assets/js/search-data.json
 ---
 {
 {%- assign i = 0 -%}
-{%- assign pages_array = '' | split: '' -%}
+{%- assign pages_array = "" | split: "" -%}
 {%- assign pages_array = pages_array | push: site.html_pages -%}
 {%- if site.just_the_docs.collections -%}
   {%- for collection_entry in site.just_the_docs.collections -%}

--- a/just-the-docs.gemspec
+++ b/just-the-docs.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "just-the-docs"
-  spec.version       = "0.4.0.rc1"
+  spec.version       = "0.4.0.rc2"
   spec.authors       = ["Patrick Marsceill", "Matthew Wang"]
   spec.email         = ["patrick.marsceill@gmail.com", "matt@matthewwang.me"]
 


### PR DESCRIPTION
https://github.com/just-the-docs/just-the-docs/releases/tag/v0.4.0.rc2 からダウンロードしたファイルを、自分たちで手をいれた部分を避けて取り込んでいます。

外部リンクをメニューに表示する設定 `nav_external_links` が追加されていたので、Doorkeeper へのリンクにしてみました。

mermaid が使えるようになっているはず。[mermaid_config.js](https://github.com/kanazawarb/meetup/blob/master/_includes/mermaid_config.js) に属性突っ込めば設定も変更できるので、使いたい方はどうぞ〜