### PR TITLE
faviconのmime-typeをimage/svg+xmlに修正する

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,1 +1,1 @@
-<link rel="shortcut icon" href="/assets/images/favicon.svg" type="image/x-icon">
+<link rel="shortcut icon" href="/assets/images/favicon.svg" type="image/svg+xml">


### PR DESCRIPTION
`image/svg+xml` が適切とのことで修正しました