### PR TITLE
reportのtemplateのlayoutがdefaultのままであったのを修正する

### DIFF
--- a/_includes/next_prev_report_link.html
+++ b/_includes/next_prev_report_link.html
@@ -8,7 +8,7 @@
       {% endif %}
     </a>
 
-    <a href="/{{ page.number | plus: 1 }}">
+    <a href="/{{ page.number | plus: 1 }}/report">
       {% if page.next %}
         next &gt;
       {% endif %}

--- a/_posts/121/report.md
+++ b/_posts/121/report.md
@@ -1,6 +1,6 @@
 ---
 
-layout: default
+layout: report
 title: "#121 report"
 nav_exclude: true
 published: true

--- a/lib/meetup_template/report.md.erb
+++ b/lib/meetup_template/report.md.erb
@@ -1,6 +1,6 @@
 ---
 
-layout: default
+layout: report
 title: "#<%= current_time %> report"
 nav_exclude: true
 published: false


### PR DESCRIPTION
`bundle exec rake meetup:gen_report` したときの、template の layout が `default` のままだったので `report` に変更した。

layout  が `report` になっていないと、report ページに `<next>`, `<prev>` のリンクが表示されない。


#### この修正で…

- `/121/report/` に next, prev のリンクが表示されるようになる
- その他 `/:id/report` の next リンクをクリックしたときに、次のレポートページに遷移する 
    - 今は イベントページに遷移してしまっている
- `bundle exec rake meetup:gen_report` したときに出力される report.md の frontmatter が `layout: report` になる 