### PR TITLE
非推奨のコマンドを新しいコマンドに置き換える

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 まずやること
 ------------
 
-    bundle install --path vendor/bundle --binstubs .bundle/bin
+    bundle config set path 'vendor/bundle'
+    bundle binstubs --path=.bundle/bin
+    bundle install
 
 作業の進め方
 ------------


### PR DESCRIPTION
# 背景
https://github.com/rubygems/rubygems/blob/6511d773b7cb070acce626f7365a1e529383be4e/bundler/UPGRADING.md
https://qiita.com/jnchito/items/d3257a5f46f4f1aee200

* bundler 3にアップグレードすると
  * `bundle install`の`--path`オプションが非推奨になる
    * 代わりに`bundle config set path`コマンドを使う
  * `bundle install`の`--binstubs`オプションが削除される
    * 代わりに`bundle binstubs`コマンドを使う

## 既知の問題
`bundle binstubs --path=.bundle/bin`の実行時に``` `bundle binstubs` needs at least one gem to run.```が出力される
https://hato-poppo.hatenablog.jp/entry/2020/10/04/154610
Gemを指定すればいいらしいのですが、どのGemを指定すればいいのか分かりません…