### PR TITLE
Doorkeeper の widget を、申込みページのリンクに置き換える

### DIFF
--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -44,12 +44,24 @@ ul.slides {
 .doorkeeper-widget {
   width : 300px;
   float:  right;
+
+  .doorkeeper-widget__text {
+    display: block;
+    text-align: right;
+
+    svg {
+      height: 1em;
+      width: 1em;
+      vertical-align: text-bottom;
+    }
+  }
 }
 
 @media screen and (max-width: 600px) {
   .doorkeeper-widget {
     float: none;
     margin: 0 auto;
+    width: 100%;
   }
 }
 

--- a/lib/meetup_template/index.md.erb
+++ b/lib/meetup_template/index.md.erb
@@ -19,7 +19,10 @@ prev: true
 -->
 
 <div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/<%= doorkeeper_id %>">kanazawa.rb meetup #<%= next_time %></a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
+  <a href="https://kzrb.doorkeeper.jp/events/<%= doorkeeper_id %>" target="_blank" rel="noopener" class="nav-list-link external doorkeeper-widget__text">
+    Doorkeeperでの申込みはこちら
+    <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
+  </a>
 </div>
 
 # Meetup #<%= next_time %>

--- a/lib/meetup_template/lt_index.md.erb
+++ b/lib/meetup_template/lt_index.md.erb
@@ -19,7 +19,10 @@ prev: true
 -->
 
 <div class="doorkeeper-widget">
-<a class="doorkeeper-reGistration-widget" href="https://kzrb.doorkeeper.jp/events/<%= doorkeeper_id %>">Kanazawa.rb meetup #<%= next_time %></a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
+  <a href="https://kzrb.doorkeeper.jp/events/<%= doorkeeper_id %>" target="_blank" rel="noopener" class="nav-list-link external doorkeeper-widget__text">
+    Doorkeeperでの申込みはこちら
+    <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
+  </a>
 </div>
 
 # Meetup #<%= next_time %>


### PR DESCRIPTION
ちょっとダサいんですが、テキストリンクに置き換えてみました。
これまでのものは申込みしないと思うのでそのままにしています。

| PC | SP |
| -- | -- |
|  ![2023-03-18_155324_scrot](https://user-images.githubusercontent.com/318352/226090700-6315206a-e096-4a9f-8092-ef04a9e1b8ff.png) | ![2023-03-18_155336_scrot](https://user-images.githubusercontent.com/318352/226090697-27a31bed-a01e-4445-88c1-333e33f55015.png) |
