### PR TITLE
meetup開催後、report.md生成時にindex.mdのDoorkeeperページへのガイド文言を変更する

### DIFF
--- a/_posts/128/index.md
+++ b/_posts/128/index.md
@@ -14,7 +14,7 @@ prev: true
 
 <div class="doorkeeper-widget">
   <a href="https://kzrb.doorkeeper.jp/events/155009" target="_blank" rel="noopener" class="nav-list-link external doorkeeper-widget__text">
-    Doorkeeperでの申込みはこちら
+    受付終了: Doorkeeperのページ
     <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
   </a>
 </div>

--- a/_posts/130/index.md
+++ b/_posts/130/index.md
@@ -14,7 +14,7 @@ prev: true
 
 <div class="doorkeeper-widget">
   <a href="https://kzrb.doorkeeper.jp/events/158419" target="_blank" rel="noopener" class="nav-list-link external doorkeeper-widget__text">
-    Doorkeeperでの申込みはこちら
+    受付終了: Doorkeeperのページ
     <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
   </a>
 </div>

--- a/lib/tasks/generate_meetup.rake
+++ b/lib/tasks/generate_meetup.rake
@@ -118,6 +118,10 @@ namespace :meetup do
     }
     event.enable_link_in_prev_report
 
+    if exist_index?(current_time)
+      event.replace_doorkeeper_guide_wording
+    end
+
     puts "_posts/#{current_time}/report.md が出力されました"
 
     default_value = 'XXX'

--- a/lib/tasks/meetup.rb
+++ b/lib/tasks/meetup.rb
@@ -156,6 +156,12 @@ module Meetup
       File.write(prev_report_path, str)
     end
 
+    def replace_doorkeeper_guide_wording
+      index_path = File.join(ROOT_PATH, "_posts", "#{@number}", "index.md")
+      str = File.read(index_path).sub("Doorkeeperでの申込みはこちら", "受付終了: Doorkeeperのページ")
+      File.write(index_path, str)
+    end
+
     private
 
     def add_event(path)


### PR DESCRIPTION
レポートのmarkdown出力時に、index.md の該当文言を置換するようにした。
よい方法とは思っていないが、出力済みmarkdownはテンプレートではないので直接書き換えるのが簡単かなというので対処している。

| 変更前 | 変更後 |
| -- | -- |
| ![230701155723](https://github.com/kanazawarb/meetup/assets/318352/a9a02aae-ea57-4406-94ab-46fb70c5aee5) | ![230701155703](https://github.com/kanazawarb/meetup/assets/318352/cfd49710-57da-44c9-96f9-23bca80d5b52) |


### 関連 issue
- https://github.com/kanazawarb/meetup/issues/1343