### PR TITLE
liquid-cの最小バージョンを設定する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,4 @@ gemspec
 gem "jekyll-github-metadata", ">= 2.15"
 gem "kramdown-parser-gfm"
 gem "webrick", "~> 1.7"
-gem "liquid-c"
+gem "liquid-c", ">= 4.0.1"


### PR DESCRIPTION
# 概要
* 一部の環境でliquid-c 4.0.0が動作しないため、Gemfileで指定しているliquid-cの最小バージョンを4.0.1に設定する
* Gemfile.lockがすでに生成されていると、そこで指定しているバージョンが使われてしまうため、あくまで使うことを想定しているバージョンを示す目的で最小バージョンを記述している

# 参考
* [Installing liquid-c using Bundler fails on Ubuntu 21.10 with Ruby 3.1.3](https://github.com/Shopify/liquid-c/issues/185)