### PR TITLE
Doorkeeperのリンクをクリックできるようにする

### DIFF
--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -37,8 +37,10 @@ ul.slides {
 
 // doorkeeper widget
 .doorkeeper-widget {
-  width : 300px;
-  float:  right;
+  width: 300px;
+  float: right;
+  position: relative;
+  z-index: 1;
 
   .doorkeeper-widget__text {
     display: block;


### PR DESCRIPTION
# 概要
- PCやタブレットで表示した際に、doorkeeper-widgetクラスを持つdiv要素の上にh1要素が重なってしまい、Doorkeeperのリンクをクリックできない
- doorkeeper-widgetクラスを持つdiv要素のz-indexを1にすることでh1要素をDoorkeeperのリンクの下に配置する