### PR TITLE
floatをFlexboxに置き換える

### DIFF
--- a/_includes/event_links.html
+++ b/_includes/event_links.html
@@ -1,0 +1,19 @@
+<div class="event-links-wrapper">
+  {% if include.event_status == "closed" %}
+    <div class="event-report">
+      <a href="/{{ include.event_times }}/report">イベントは終了しました。レポートはこちら</a>
+    </div>
+  {% endif %}
+  {% if include.doorkeeper_url %}
+    <div class="event-participation">
+      <a href="{{ include.doorkeeper_url }}" target="_blank" rel="noopener" class="nav-list-link external">
+        {% if include.event_status == "open" %}
+          Doorkeeperでの申込みはこちら
+        {% elsif include.event_status == "closed" %}
+          受付終了: Doorkeeperのページ
+        {% endif %}
+        <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
+      </a>
+    </div>
+  {% endif %}
+</div>

--- a/_includes/event_links.html
+++ b/_includes/event_links.html
@@ -1,7 +1,7 @@
 <div class="event-links-wrapper">
   {% assign report_path = page.url | append: "report.md"  %}
   {% capture report_exists %}{% file_exists {{ report_path }} %}{% endcapture %}
-  {% if include.event_status == "closed" and report_exists == "true" %}
+  {% if include.is_event_open_or_closed == "closed" and report_exists == "true" %}
     <div class="event-report">
       <a href="{{ page.url }}report">イベントは終了しました。レポートはこちら</a>
     </div>
@@ -9,9 +9,9 @@
   {% if include.doorkeeper_url %}
     <div class="event-participation">
       <a href="{{ include.doorkeeper_url }}" target="_blank" rel="noopener" class="nav-list-link external">
-        {% if include.event_status == "open" %}
+        {% if include.is_event_open_or_closed == "open" %}
           Doorkeeperでの申込みはこちら
-        {% elsif include.event_status == "closed" %}
+        {% elsif include.is_event_open_or_closed == "closed" %}
           受付終了: Doorkeeperのページ
         {% endif %}
         <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>

--- a/_includes/event_links.html
+++ b/_includes/event_links.html
@@ -1,7 +1,9 @@
 <div class="event-links-wrapper">
-  {% if include.event_status == "closed" %}
+  {% assign report_path = page.url | append: "report.md"  %}
+  {% capture report_exists %}{% file_exists {{ report_path }} %}{% endcapture %}
+  {% if include.event_status == "closed" and report_exists == "true" %}
     <div class="event-report">
-      <a href="/{{ include.event_times }}/report">イベントは終了しました。レポートはこちら</a>
+      <a href="{{ page.url }}report">イベントは終了しました。レポートはこちら</a>
     </div>
   {% endif %}
   {% if include.doorkeeper_url %}

--- a/_posts/1/index.md
+++ b/_posts/1/index.md
@@ -8,11 +8,7 @@ next: true
 prev: true
 ---
 
-<div class="event-links-wrapper">
-  <div class="event-report">
-    <a href="/1/report">イベントは終了しました。レポートはこちら</a>
-  </div>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" %}
 
 kanazawa.rbってなに
 ===================

--- a/_posts/1/index.md
+++ b/_posts/1/index.md
@@ -8,8 +8,11 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/1/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
+<div class="event-links-wrapper">
+  <div class="event-report">
+    <a href="/1/report">イベントは終了しました。レポートはこちら</a>
+  </div>
+</div>
 
 kanazawa.rbってなに
 ===================

--- a/_posts/10/index.md
+++ b/_posts/10/index.md
@@ -8,17 +8,7 @@ next: true
 prev: true
 ---
 
-<div class="event-links-wrapper">
-  <div class="event-report">
-    <a href="/10/report">イベントは終了しました。レポートはこちら</a>
-  </div>
-  <div class="event-participation">
-    <a href="http://kzrb.doorkeeper.jp/events/4106" target="_blank" rel="noopener" class="nav-list-link external">
-      受付終了: Doorkeeperのページ
-      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-    </a>
-  </div>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="http://kzrb.doorkeeper.jp/events/4106" %}
 
 meetup #10
 ===========

--- a/_posts/10/index.md
+++ b/_posts/10/index.md
@@ -8,15 +8,13 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/10/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
-
-<div class="doorkeeper-widget">
-<a href="http://kzrb.doorkeeper.jp/events/4106" class="doorkeeper-registration-widget">meetup
-#10</a>
-
-<script src="https://d1dqic1fklzs1z.cloudfront.net/assets/widget.js" type="text/javascript">
-</script>
+<div class="event-links-wrapper">
+  <div class="event-report">
+    <a href="/10/report">イベントは終了しました。レポートはこちら</a>
+  </div>
+  <div>
+    <a href="http://kzrb.doorkeeper.jp/events/4106">meetup #10</a>
+  </div>
 </div>
 
 meetup #10

--- a/_posts/10/index.md
+++ b/_posts/10/index.md
@@ -12,8 +12,11 @@ prev: true
   <div class="event-report">
     <a href="/10/report">イベントは終了しました。レポートはこちら</a>
   </div>
-  <div>
-    <a href="http://kzrb.doorkeeper.jp/events/4106">meetup #10</a>
+  <div class="event-participation">
+    <a href="http://kzrb.doorkeeper.jp/events/4106" target="_blank" rel="noopener" class="nav-list-link external">
+      受付終了: Doorkeeperのページ
+      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
+    </a>
   </div>
 </div>
 

--- a/_posts/100/index.md
+++ b/_posts/100/index.md
@@ -9,13 +9,9 @@ next: true
 prev: true
 ---
 
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/114713" %}
+
 # meetup #100
-
-<div style="text-align: right;"><a href="/100/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/114713">kanazawa.rb meetup #100</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
 
 ## 祝100回記念 & 年末 LT 大会 - オンライン
 

--- a/_posts/101/index.md
+++ b/_posts/101/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/101/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/116243">kanazawa.rb meetup #101</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/116243" %}
 
 # meetup #101
 

--- a/_posts/102/index.md
+++ b/_posts/102/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/102/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/117972">kanazawa.rb meetup #102</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/117972" %}
 
 # meetup #102
 

--- a/_posts/103/index.md
+++ b/_posts/103/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/103/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/119484">kanazawa.rb meetup #103</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/119484" %}
 
 # meetup #103
 

--- a/_posts/104/index.md
+++ b/_posts/104/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/104/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/120425">kanazawa.rb meetup #104</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/120425" %}
 
 # meetup #104
 

--- a/_posts/105/index.md
+++ b/_posts/105/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/105/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/121161">kanazawa.rb meetup #105</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/121161" %}
 
 # meetup #105
 

--- a/_posts/106/index.md
+++ b/_posts/106/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/106/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/123089">kanazawa.rb meetup #106</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/123089" %}
 
 # meetup #106
 

--- a/_posts/107/index.md
+++ b/_posts/107/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/107/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/124276">kanazawa.rb meetup #107</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/124276" %}
 
 # meetup #107
 

--- a/_posts/108/index.md
+++ b/_posts/108/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/108/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/125406">kanazawa.rb meetup #108</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/125406" %}
 
 # meetup #108
 
@@ -126,7 +122,7 @@ kanazawa.rb はカンファレンスでも勉強会でもない！
 | エアコンの操作についての話 | | 5min |  井澤ゆきみつさん |
 | Rspecを学ぶにあたって参考になった本・記事 | | 5min | Ryusei Nomi(とんと)さん |
 | Swagger頑張ったー | | 5min |  Keisuke Oohataさん |
-| ソーシャルネットワークで炎上を避けるノウハウ | | 5min | satさん | 
+| ソーシャルネットワークで炎上を避けるノウハウ | | 5min | satさん |
 | 最近のデスク周りの diff | | 5min |  muryoimplさん |
 | Kubernetes知らない人にKubernetesのoperatorを説明する| | 5min |  satさん |
 | geektoolでライブ壁紙  | | 5min | izawa |

--- a/_posts/109/index.md
+++ b/_posts/109/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/109/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/126799">kanazawa.rb meetup #109</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/126799" %}
 
 # meetup #109
 

--- a/_posts/11/index.md
+++ b/_posts/11/index.md
@@ -8,17 +8,7 @@ next: true
 prev: true
 ---
 
-<div class="event-links-wrapper">
-  <div class="event-report">
-    <a href="/11/report">イベントは終了しました。レポートはこちら</a>
-  </div>
-  <div class="event-participation">
-    <a href="http://kzrb.doorkeeper.jp/events/4679" target="_blank" rel="noopener" class="nav-list-link external">
-      受付終了: Doorkeeperのページ
-      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-    </a>
-  </div>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="http://kzrb.doorkeeper.jp/events/4679" %}
 
 meetup #11
 ===========

--- a/_posts/11/index.md
+++ b/_posts/11/index.md
@@ -8,15 +8,13 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/11/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
-
-<div class="doorkeeper-widget">
-<a href="http://kzrb.doorkeeper.jp/events/4679" class="doorkeeper-registration-widget">meetup
-#11</a>
-
-<script src="https://d1dqic1fklzs1z.cloudfront.net/assets/widget.js" type="text/javascript">
-</script>
+<div class="event-links-wrapper">
+  <div class="event-report">
+    <a href="/11/report">イベントは終了しました。レポートはこちら</a>
+  </div>
+  <div>
+    <a href="http://kzrb.doorkeeper.jp/events/4679">meetup #11</a>
+  </div>
 </div>
 
 meetup #11

--- a/_posts/11/index.md
+++ b/_posts/11/index.md
@@ -12,8 +12,11 @@ prev: true
   <div class="event-report">
     <a href="/11/report">イベントは終了しました。レポートはこちら</a>
   </div>
-  <div>
-    <a href="http://kzrb.doorkeeper.jp/events/4679">meetup #11</a>
+  <div class="event-participation">
+    <a href="http://kzrb.doorkeeper.jp/events/4679" target="_blank" rel="noopener" class="nav-list-link external">
+      受付終了: Doorkeeperのページ
+      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
+    </a>
   </div>
 </div>
 

--- a/_posts/110/index.md
+++ b/_posts/110/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/110/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/127617">kanazawa.rb meetup #110</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/127617" %}
 
 # meetup #110
 
@@ -53,11 +49,11 @@ prev: true
 | タイトル                          | 時刻  | 時間 | 担当                                                    |
 |:----------------------------------|:-----:|:----:|:--------------------------------------------------------|
 | 開場                              | 13:00 |      |                                                         |
-| 自己紹介                           | 13:15 | 15m  | みんな                                                    | 
-| kanazawa.rb コミュニティの紹介      | 13:30 | 15m  | kanazawa.rb 井澤さん                                       |  
+| 自己紹介                           | 13:15 | 15m  | みんな                                                    |
+| kanazawa.rb コミュニティの紹介      | 13:30 | 15m  | kanazawa.rb 井澤さん                                       |
 | みんなのCSIRT コミュニティの紹介     | 13:45 | 15m  | みんなのCSIRT 小西さん                                      |
-| 梅内翼さん解説＋ハンズオン           | 14:00 | 60m  | 梅内翼さん                                                 | 
-| 休憩                             | 15:00 | 10m  |                                                           | 
+| 梅内翼さん解説＋ハンズオン           | 14:00 | 60m  | 梅内翼さん                                                 |
+| 休憩                             | 15:00 | 10m  |                                                           |
 | サイドチャネル攻撃のハンズオン＋解説  | 15:10 | 45m  | みんなのCSIRT 小西さん                                       |
 | 休憩                             | 15:55 | 10m  |                                                          |
 | ディスカッション                   | 16:05 | 45m  | みんな                                                     |
@@ -69,20 +65,20 @@ prev: true
   <a href="https://www.amazon.co.jp/gp/product/B094J7ZCJN/"><img src="https://images-na.ssl-images-amazon.com/images/I/51YSEjPKQdL._SL160_.jpg" height="160" width="109" alt="" title="" /></a>
 </div>
 
-セキュリティ競技CTFを幅広く丁寧に解説  
-情報セキュリティ技術を競う競技であるセキュリティコンテスト：CTF（Capture the Flag）。  
-本書ではCTFの基礎を、技術的な背景の解説を通して実践的に学んでいく一冊です。  
-現代のCTFにおいて主流である  
-　・Web (Webアプリケーションへの攻撃)  
-　・Crypto (暗号解読)  
-　・Reversing (バイナリ解析)  
-　・Pwnable (低級プログラムの掌握)  
-の4ジャンルについて取り扱います。  
+セキュリティ競技CTFを幅広く丁寧に解説
+情報セキュリティ技術を競う競技であるセキュリティコンテスト：CTF（Capture the Flag）。
+本書ではCTFの基礎を、技術的な背景の解説を通して実践的に学んでいく一冊です。
+現代のCTFにおいて主流である
+　・Web (Webアプリケーションへの攻撃)
+　・Crypto (暗号解読)
+　・Reversing (バイナリ解析)
+　・Pwnable (低級プログラムの掌握)
+の4ジャンルについて取り扱います。
 各パートの冒頭には、必要な基礎知識の説明が用意されています。幅広くかつ丁寧に解説していますので、現代CTFの傾向が理解できるとともに、競技を楽しむための足腰を鍛えることができます。
 「問題をどのような目線で分析するか」「どのような時に、どの解法を検討するか」といった、問題と向き合う際の思考法への言及にも注目してみてください。
-  
-情報セキュリティの技を磨く足掛かりに。  
-CTFに臨むための技術を理論と実践で身に付けよう  
+
+情報セキュリティの技を磨く足掛かりに。
+CTFに臨むための技術を理論と実践で身に付けよう
 
 ## 懇親会について
 

--- a/_posts/111/index.md
+++ b/_posts/111/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/111/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/129676">kanazawa.rb meetup #111</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/129676" %}
 
 # meetup #111
 

--- a/_posts/112/index.md
+++ b/_posts/112/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/112/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/130604">kanazawa.rb meetup #112</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/130604" %}
 
 # meetup #112
 

--- a/_posts/113/index.md
+++ b/_posts/113/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/113/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/131804">kanazawa.rb meetup #113</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/131804" %}
 
 # meetup #113
 

--- a/_posts/114/index.md
+++ b/_posts/114/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/114/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/133180">kanazawa.rb meetup #114</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/133180" %}
 
 # meetup #114
 

--- a/_posts/115/index.md
+++ b/_posts/115/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/115/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/134127">kanazawa.rb meetup #115</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/134127" %}
 
 # meetup #115
 

--- a/_posts/116/index.md
+++ b/_posts/116/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/116/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/135579">kanazawa.rb meetup #116</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/135579" %}
 
 # meetup #116
 

--- a/_posts/117/index.md
+++ b/_posts/117/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/117/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/136853">kanazawa.rb meetup #117</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/136853" %}
 
 # meetup #117
 

--- a/_posts/118/index.md
+++ b/_posts/118/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/118/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/138406">kanazawa.rb meetup #118</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/138406" %}
 
 # meetup #118
 

--- a/_posts/119/index.md
+++ b/_posts/119/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/119/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/139487">kanazawa.rb meetup #119</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/139487" %}
 
 # meetup #119
 

--- a/_posts/12/index.md
+++ b/_posts/12/index.md
@@ -8,17 +8,7 @@ next: true
 prev: true
 ---
 
-<div class="event-links-wrapper">
-  <div class="event-report">
-    <a href="/12/report">イベントは終了しました。レポートはこちら</a>
-  </div>
-  <div class="event-participation">
-    <a href="http://kzrb.doorkeeper.jp/events/5220" target="_blank" rel="noopener" class="nav-list-link external">
-      受付終了: Doorkeeperのページ
-      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-    </a>
-  </div>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="http://kzrb.doorkeeper.jp/events/5220" %}
 
 meetup #12
 ===========

--- a/_posts/12/index.md
+++ b/_posts/12/index.md
@@ -12,8 +12,11 @@ prev: true
   <div class="event-report">
     <a href="/12/report">イベントは終了しました。レポートはこちら</a>
   </div>
-  <div>
-    <a href="http://kzrb.doorkeeper.jp/events/5220">meetup #12</a>
+  <div class="event-participation">
+    <a href="http://kzrb.doorkeeper.jp/events/5220" target="_blank" rel="noopener" class="nav-list-link external">
+      受付終了: Doorkeeperのページ
+      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
+    </a>
   </div>
 </div>
 

--- a/_posts/12/index.md
+++ b/_posts/12/index.md
@@ -8,15 +8,13 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/12/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
-
-<div class="doorkeeper-widget">
-<a href="http://kzrb.doorkeeper.jp/events/5220" class="doorkeeper-registration-widget">meetup
-#12</a>
-
-<script src="https://d1dqic1fklzs1z.cloudfront.net/assets/widget.js" type="text/javascript">
-</script>
+<div class="event-links-wrapper">
+  <div class="event-report">
+    <a href="/12/report">イベントは終了しました。レポートはこちら</a>
+  </div>
+  <div>
+    <a href="http://kzrb.doorkeeper.jp/events/5220">meetup #12</a>
+  </div>
 </div>
 
 meetup #12

--- a/_posts/120/index.md
+++ b/_posts/120/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/120/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/141516">kanazawa.rb meetup #120</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/141516" %}
 
 # meetup #120
 
@@ -79,24 +75,24 @@ Tシャツはいくつかのカラーバリエーションがあり、サイズ�
 | 開場                              | 13:00 |      |                                                         |
 | オープニング＆発表順決定          | 13:15 | 30m  | みんな                                                  |
 | LT                                | 13:45 |      | みんな                                                  |
-| LT: kanazawa.rb に参加してからの振り返り     | | | takayukiatkwsk       | 
-| LT: 最近読んだ本の話                         | | | Jun Nakano           | 
-| LT: meetup.kzrb.org の更新を考える その1     | | | muryoimpl            | 
-| LT: meetup.kzrb.org の更新を考える その2     | | | muryoimpl            | 
+| LT: kanazawa.rb に参加してからの振り返り     | | | takayukiatkwsk       |
+| LT: 最近読んだ本の話                         | | | Jun Nakano           |
+| LT: meetup.kzrb.org の更新を考える その1     | | | muryoimpl            |
+| LT: meetup.kzrb.org の更新を考える その2     | | | muryoimpl            |
 | 休憩                                         | | |                      |
-| LT: お試し sidekiq                           | | | Ryusei Nomi(とんと)  | 
-| LT: 私の散歩道                               | | | Kentaro Matsushita   | 
-| LT: git secrets と git hook をざっと理解する | | | takayukiatkwsk       | 
-| LT: 散財係数爆上がり中                       | | | Keisuke Oohata       | 
+| LT: お試し sidekiq                           | | | Ryusei Nomi(とんと)  |
+| LT: 私の散歩道                               | | | Kentaro Matsushita   |
+| LT: git secrets と git hook をざっと理解する | | | takayukiatkwsk       |
+| LT: 散財係数爆上がり中                       | | | Keisuke Oohata       |
 | 休憩                                         | | |                      |
-| LT: concern のテストを書く                   | | | Ryusei Nomi(とんと)  | 
-| LT: スライドタイトルで振り返るこの10年       | | | ふぁらお加藤         | 
-| LT: 写真で振り返る kanazawa.rb               | | | ふぁらお加藤         | 
-| LT: レザークラフトをやってみたよ             | | | 井澤ゆきみつ         | 
+| LT: concern のテストを書く                   | | | Ryusei Nomi(とんと)  |
+| LT: スライドタイトルで振り返るこの10年       | | | ふぁらお加藤         |
+| LT: 写真で振り返る kanazawa.rb               | | | ふぁらお加藤         |
+| LT: レザークラフトをやってみたよ             | | | 井澤ゆきみつ         |
 | 休憩                                         | | |                      |
 | LT: THE FIRST CODE                           | | | sat                  |
 | LT: kubernetesコントローラのプログラミングモデル | | | sat              |
-| LT: kanazawa.rb 10周年 KPT                   | | | Keisuke Oohata       | 
+| LT: kanazawa.rb 10周年 KPT                   | | | Keisuke Oohata       |
 | 運営ブレスト                      | 16:25 | 30m  | 有志                                                    |
 | 片付け＆撤収                      | 16:55 | 5m   | みんな                                                  |
 

--- a/_posts/121/index.md
+++ b/_posts/121/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/121/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/142982">kanazawa.rb meetup #121</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/142982" %}
 
 # meetup #121
 

--- a/_posts/122/index.md
+++ b/_posts/122/index.md
@@ -10,11 +10,7 @@ prev: true
 
 ---
 
-<div style="text-align: right;"><a href="/122/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/144791">kanazawa.rb meetup #122</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/144791" %}
 
 # meetup #122
 

--- a/_posts/123/index.md
+++ b/_posts/123/index.md
@@ -10,11 +10,7 @@ prev: true
 
 ---
 
-<div style="text-align: right;"><a href="/123/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/146326">kanazawa.rb meetup #123</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/146326" %}
 
 # Meetup #123
 

--- a/_posts/124/index.md
+++ b/_posts/124/index.md
@@ -10,11 +10,7 @@ prev: true
 
 ---
 
-<div style="text-align: right;"><a href="/124/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/148251">kanazawa.rb meetup #124</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/148251" %}
 
 # Meetup #124
 

--- a/_posts/125/index.md
+++ b/_posts/125/index.md
@@ -10,11 +10,7 @@ prev: true
 
 ---
 
-<div style="text-align: right;"><a href="/125/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/149327">kanazawa.rb meetup #125</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/149327" %}
 
 # Meetup #125
 

--- a/_posts/126/index.md
+++ b/_posts/126/index.md
@@ -10,11 +10,7 @@ prev: true
 
 ---
 
-<div style="text-align: right;"><a href="/126/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/151475">kanazawa.rb meetup #126</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/151475" %}
 
 # Meetup #126
 

--- a/_posts/127/index.md
+++ b/_posts/127/index.md
@@ -10,11 +10,7 @@ prev: true
 
 ---
 
-<div style="text-align: right;"><a href="/127/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/152375">kanazawa.rb meetup #127</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/152375" %}
 
 # Meetup #127
 

--- a/_posts/128/index.md
+++ b/_posts/128/index.md
@@ -10,14 +10,7 @@ prev: true
 
 ---
 
-<div style="text-align: right;"><a href="/128/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-  <a href="https://kzrb.doorkeeper.jp/events/155009" target="_blank" rel="noopener" class="nav-list-link external doorkeeper-widget__text">
-    受付終了: Doorkeeperのページ
-    <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-  </a>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/155009" %}
 
 # Meetup #128
 

--- a/_posts/129/index.md
+++ b/_posts/129/index.md
@@ -10,13 +10,13 @@ prev: true
 
 ---
 
-<div style="text-align: right;"><a href="/129/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
+{% include event_links.html is_event_open_or_closed="closed" %}
 
 # Cloudflare Meetup Kanazawa Kick off!! (meetup #129)
 
 Kanazawa.rb, [Toyama.rb](https://toyamarb.github.io/), [ふくもく会](https://fukumoku.connpass.com/) の三つの勉強会コミュニティのバックアップのもと、 [Cloudflare](https://www.cloudflare.com/ja-jp/) の公式 meetup が金沢で開催されます。
 
-インターネット全体の高機能化や高速化を司る Cloudflare. 
+インターネット全体の高機能化や高速化を司る Cloudflare.
 代表的なサービスである CDN だけにとどまらず、多様なサービスが次々と追加されています。
 2023年の今、どういったサービスがあり、どういった用途に使えるのか、基本的なところから網羅的にお話を伺い、自分たちのサービス運用に活用しましょう！
 

--- a/_posts/13/index.md
+++ b/_posts/13/index.md
@@ -9,17 +9,7 @@ next: true
 prev: true
 ---
 
-<div class="event-links-wrapper">
-  <div class="event-report">
-    <a href="/13/report">イベントは終了しました。レポートはこちら</a>
-  </div>
-  <div class="event-participation">
-    <a href="http://kzrb.doorkeeper.jp/events/5667" target="_blank" rel="noopener" class="nav-list-link external">
-      受付終了: Doorkeeperのページ
-      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-    </a>
-  </div>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="http://kzrb.doorkeeper.jp/events/5667" %}
 
 meetup #13
 ===========

--- a/_posts/13/index.md
+++ b/_posts/13/index.md
@@ -9,15 +9,13 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/13/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
-
-<div class="doorkeeper-widget">
-<a href="http://kzrb.doorkeeper.jp/events/5667" class="doorkeeper-registration-widget">meetup
-#13</a>
-
-<script src="https://d1dqic1fklzs1z.cloudfront.net/assets/widget.js" type="text/javascript">
-</script>
+<div class="event-links-wrapper">
+  <div class="event-report">
+    <a href="/13/report">イベントは終了しました。レポートはこちら</a>
+  </div>
+  <div>
+    <a href="http://kzrb.doorkeeper.jp/events/5667">meetup #13</a>
+  </div>
 </div>
 
 meetup #13

--- a/_posts/13/index.md
+++ b/_posts/13/index.md
@@ -13,8 +13,11 @@ prev: true
   <div class="event-report">
     <a href="/13/report">イベントは終了しました。レポートはこちら</a>
   </div>
-  <div>
-    <a href="http://kzrb.doorkeeper.jp/events/5667">meetup #13</a>
+  <div class="event-participation">
+    <a href="http://kzrb.doorkeeper.jp/events/5667" target="_blank" rel="noopener" class="nav-list-link external">
+      受付終了: Doorkeeperのページ
+      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
+    </a>
   </div>
 </div>
 

--- a/_posts/130/index.md
+++ b/_posts/130/index.md
@@ -10,14 +10,7 @@ prev: true
 
 ---
 
-<div style="text-align: right;"><a href="/130/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-  <a href="https://kzrb.doorkeeper.jp/events/158419" target="_blank" rel="noopener" class="nav-list-link external doorkeeper-widget__text">
-    受付終了: Doorkeeperのページ
-    <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-  </a>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/158419" %}
 
 # Meetup #130
 

--- a/_posts/131/index.md
+++ b/_posts/131/index.md
@@ -10,14 +10,7 @@ prev: true
 
 ---
 
-<div style="text-align: right;"><a href="/131/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-  <a href="https://kzrb.doorkeeper.jp/events/159926" target="_blank" rel="noopener" class="nav-list-link external doorkeeper-widget__text">
-    受付終了: Doorkeeperのページ
-    <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-  </a>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/159926" %}
 
 # Meetup #131
 

--- a/_posts/132/index.md
+++ b/_posts/132/index.md
@@ -10,14 +10,7 @@ prev: true
 
 ---
 
-<div style="text-align: right;"><a href="/132/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-  <a href="https://kzrb.doorkeeper.jp/events/161435" target="_blank" rel="noopener" class="nav-list-link external doorkeeper-widget__text">
-    受付終了: Doorkeeperのページ
-    <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-  </a>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/161435" %}
 
 # Meetup #132
 

--- a/_posts/133/index.md
+++ b/_posts/133/index.md
@@ -10,14 +10,7 @@ prev: true
 
 ---
 
-<div style="text-align: right;"><a href="/133/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-  <a href="https://kzrb.doorkeeper.jp/events/163391" target="_blank" rel="noopener" class="nav-list-link external doorkeeper-widget__text">
-    受付終了: Doorkeeperのページ
-    <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-  </a>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/163391" %}
 
 # Meetup #133
 

--- a/_posts/134/index.md
+++ b/_posts/134/index.md
@@ -10,14 +10,7 @@ prev: true
 
 ---
 
-<div style="text-align: right;"><a href="/134/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-  <a href="https://kzrb.doorkeeper.jp/events/164401" target="_blank" rel="noopener" class="nav-list-link external doorkeeper-widget__text">
-    受付終了: Doorkeeperのページ
-    <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-  </a>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/164401" %}
 
 # Meetup #134
 

--- a/_posts/135/index.md
+++ b/_posts/135/index.md
@@ -10,14 +10,7 @@ prev: true
 
 ---
 
-<div style="text-align: right;"><a href="/135/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-  <a href="https://jawsug-kanazawa.doorkeeper.jp/events/163630" target="_blank" rel="noopener" class="nav-list-link external doorkeeper-widget__text">
-    受付終了: Doorkeeperのページ
-    <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-  </a>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://jawsug-kanazawa.doorkeeper.jp/events/163630" %}
 
 # Ruby on Rails on App Runner ハンズオン(meetup #135)
 

--- a/_posts/136/index.md
+++ b/_posts/136/index.md
@@ -10,14 +10,7 @@ prev: true
 
 ---
 
-<div style="text-align: right;"><a href="/136/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-  <a href="https://kzrb.doorkeeper.jp/events/167128" target="_blank" rel="noopener" class="nav-list-link external doorkeeper-widget__text">
-    受付終了: Doorkeeperのページ
-    <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-  </a>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/167128" %}
 
 # Meetup #136
 

--- a/_posts/137/index.md
+++ b/_posts/137/index.md
@@ -10,14 +10,7 @@ prev: true
 
 ---
 
-<div style="text-align: right;"><a href="/137/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-  <a href="https://kzrb.doorkeeper.jp/events/167775" target="_blank" rel="noopener" class="nav-list-link external doorkeeper-widget__text">
-    受付終了: Doorkeeperのページ
-    <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-  </a>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/167775" %}
 
 # Meetup #137
 

--- a/_posts/138/index.md
+++ b/_posts/138/index.md
@@ -10,14 +10,7 @@ prev: true
 
 ---
 
-<div style="text-align: right;"><a href="/138/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-  <a href="https://kzrb.doorkeeper.jp/events/169105" target="_blank" rel="noopener" class="nav-list-link external doorkeeper-widget__text">
-    受付終了: Doorkeeperのページ
-    <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-  </a>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/169105" %}
 
 # Meetup #138
 

--- a/_posts/139/index.md
+++ b/_posts/139/index.md
@@ -10,14 +10,7 @@ prev: true
 
 ---
 
-<div style="text-align: right;"><a href="/139/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-  <a href="https://kzrb.doorkeeper.jp/events/170383" target="_blank" rel="noopener" class="nav-list-link external doorkeeper-widget__text">
-    受付終了: Doorkeeperのページ
-    <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-  </a>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/170383" %}
 
 # Meetup #139
 

--- a/_posts/14/index.md
+++ b/_posts/14/index.md
@@ -9,17 +9,7 @@ next: true
 prev: true
 ---
 
-<div class="event-links-wrapper">
-  <div class="event-report">
-    <a href="/14/report">イベントは終了しました。レポートはこちら</a>
-  </div>
-  <div class="event-participation">
-    <a href="http://kzrb.doorkeeper.jp/events/6270" target="_blank" rel="noopener" class="nav-list-link external">
-      受付終了: Doorkeeperのページ
-      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-    </a>
-  </div>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="http://kzrb.doorkeeper.jp/events/6270" %}
 
 meetup #14
 ===========

--- a/_posts/14/index.md
+++ b/_posts/14/index.md
@@ -9,15 +9,13 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/14/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
-
-<div class="doorkeeper-widget">
-<a href="http://kzrb.doorkeeper.jp/events/6270" class="doorkeeper-registration-widget">meetup
-#14</a>
-
-<script src="https://d1dqic1fklzs1z.cloudfront.net/assets/widget.js" type="text/javascript">
-</script>
+<div class="event-links-wrapper">
+  <div class="event-report">
+    <a href="/14/report">イベントは終了しました。レポートはこちら</a>
+  </div>
+  <div>
+    <a href="http://kzrb.doorkeeper.jp/events/6270">meetup #14</a>
+  </div>
 </div>
 
 meetup #14

--- a/_posts/14/index.md
+++ b/_posts/14/index.md
@@ -13,8 +13,11 @@ prev: true
   <div class="event-report">
     <a href="/14/report">イベントは終了しました。レポートはこちら</a>
   </div>
-  <div>
-    <a href="http://kzrb.doorkeeper.jp/events/6270">meetup #14</a>
+  <div class="event-participation">
+    <a href="http://kzrb.doorkeeper.jp/events/6270" target="_blank" rel="noopener" class="nav-list-link external">
+      受付終了: Doorkeeperのページ
+      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
+    </a>
   </div>
 </div>
 

--- a/_posts/15/index.md
+++ b/_posts/15/index.md
@@ -9,17 +9,7 @@ next: true
 prev: true
 ---
 
-<div class="event-links-wrapper">
-  <div class="event-report">
-    <a href="/15/report">イベントは終了しました。レポートはこちら</a>
-  </div>
-  <div class="event-participation">
-    <a href="http://kzrb.doorkeeper.jp/events/6745" target="_blank" rel="noopener" class="nav-list-link external">
-      受付終了: Doorkeeperのページ
-      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-    </a>
-  </div>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="http://kzrb.doorkeeper.jp/events/6745" %}
 
 meetup #15
 ===========

--- a/_posts/15/index.md
+++ b/_posts/15/index.md
@@ -9,13 +9,16 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/15/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
-
-<div class="doorkeeper-widget">
-<a href="http://kzrb.doorkeeper.jp/events/6745" class="doorkeeper-registration-widget">meetup
-#15</a><script src="https://widgets.doorkeeper.jp/w/widget.js" type="text/javascript"></script>
-
+<div class="event-links-wrapper">
+  <div class="event-report">
+    <a href="/15/report">イベントは終了しました。レポートはこちら</a>
+  </div>
+  <div class="event-participation">
+    <a href="http://kzrb.doorkeeper.jp/events/6745" target="_blank" rel="noopener" class="nav-list-link external">
+      受付終了: Doorkeeperのページ
+      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
+    </a>
+  </div>
 </div>
 
 meetup #15

--- a/_posts/16/index.md
+++ b/_posts/16/index.md
@@ -9,17 +9,7 @@ next: true
 prev: true
 ---
 
-<div class="event-links-wrapper">
-  <div class="event-report">
-    <a href="/16/report">イベントは終了しました。レポートはこちら</a>
-  </div>
-  <div class="event-participation">
-    <a href="http://kzrb.doorkeeper.jp/events/7389" target="_blank" rel="noopener" class="nav-list-link external">
-      受付終了: Doorkeeperのページ
-      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-    </a>
-  </div>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="http://kzrb.doorkeeper.jp/events/7389" %}
 
 meetup #16
 ===========

--- a/_posts/16/index.md
+++ b/_posts/16/index.md
@@ -9,13 +9,16 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/16/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
-
-<div class="doorkeeper-widget">
-<a href="http://kzrb.doorkeeper.jp/events/7389" class="doorkeeper-registration-widget">meetup
-#16</a><script src="https://widgets.doorkeeper.jp/w/widget.js" type="text/javascript"></script>
-
+<div class="event-links-wrapper">
+  <div class="event-report">
+    <a href="/16/report">イベントは終了しました。レポートはこちら</a>
+  </div>
+  <div class="event-participation">
+    <a href="http://kzrb.doorkeeper.jp/events/7389" target="_blank" rel="noopener" class="nav-list-link external">
+      受付終了: Doorkeeperのページ
+      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
+    </a>
+  </div>
 </div>
 
 meetup #16

--- a/_posts/17/index.md
+++ b/_posts/17/index.md
@@ -9,13 +9,16 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/17/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
-
-<div class="doorkeeper-widget">
-<a href="http://kzrb.doorkeeper.jp/events/8073" class="doorkeeper-registration-widget">meetup
-#17</a><script src="https://widgets.doorkeeper.jp/w/widget.js" type="text/javascript"></script>
-
+<div class="event-links-wrapper">
+  <div class="event-report">
+    <a href="/17/report">イベントは終了しました。レポートはこちら</a>
+  </div>
+  <div class="event-participation">
+    <a href="http://kzrb.doorkeeper.jp/events/8073" target="_blank" rel="noopener" class="nav-list-link external">
+      受付終了: Doorkeeperのページ
+      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
+    </a>
+  </div>
 </div>
 
 meetup #17

--- a/_posts/17/index.md
+++ b/_posts/17/index.md
@@ -9,17 +9,7 @@ next: true
 prev: true
 ---
 
-<div class="event-links-wrapper">
-  <div class="event-report">
-    <a href="/17/report">イベントは終了しました。レポートはこちら</a>
-  </div>
-  <div class="event-participation">
-    <a href="http://kzrb.doorkeeper.jp/events/8073" target="_blank" rel="noopener" class="nav-list-link external">
-      受付終了: Doorkeeperのページ
-      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-    </a>
-  </div>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="http://kzrb.doorkeeper.jp/events/8073" %}
 
 meetup #17
 ===========

--- a/_posts/18/index.md
+++ b/_posts/18/index.md
@@ -9,13 +9,16 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/18/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
-
-<div class="doorkeeper-widget">
-<a href="http://kzrb.doorkeeper.jp/events/8563" class="doorkeeper-registration-widget">meetup
-#18</a><script src="https://widgets.doorkeeper.jp/w/widget.js" type="text/javascript"></script>
-
+<div class="event-links-wrapper">
+  <div class="event-report">
+    <a href="/18/report">イベントは終了しました。レポートはこちら</a>
+  </div>
+  <div class="event-participation">
+    <a href="http://kzrb.doorkeeper.jp/events/8563" target="_blank" rel="noopener" class="nav-list-link external">
+      受付終了: Doorkeeperのページ
+      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
+    </a>
+  </div>
 </div>
 
 meetup #18

--- a/_posts/18/index.md
+++ b/_posts/18/index.md
@@ -9,17 +9,7 @@ next: true
 prev: true
 ---
 
-<div class="event-links-wrapper">
-  <div class="event-report">
-    <a href="/18/report">イベントは終了しました。レポートはこちら</a>
-  </div>
-  <div class="event-participation">
-    <a href="http://kzrb.doorkeeper.jp/events/8563" target="_blank" rel="noopener" class="nav-list-link external">
-      受付終了: Doorkeeperのページ
-      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-    </a>
-  </div>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="http://kzrb.doorkeeper.jp/events/8563" %}
 
 meetup #18
 ===========

--- a/_posts/19/index.md
+++ b/_posts/19/index.md
@@ -9,17 +9,7 @@ next: true
 prev: true
 ---
 
-<div class="event-links-wrapper">
-  <div class="event-report">
-    <a href="/19/report">イベントは終了しました。レポートはこちら</a>
-  </div>
-  <div class="event-participation">
-    <a href="http://kzrb.doorkeeper.jp/events/9456" target="_blank" rel="noopener" class="nav-list-link external">
-      受付終了: Doorkeeperのページ
-      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-    </a>
-  </div>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="http://kzrb.doorkeeper.jp/events/9456" %}
 
 meetup #19
 ===========

--- a/_posts/19/index.md
+++ b/_posts/19/index.md
@@ -9,13 +9,16 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/19/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
-
-<div class="doorkeeper-widget">
-<a href="http://kzrb.doorkeeper.jp/events/9456" class="doorkeeper-registration-widget">meetup
-#19</a><script src="https://widgets.doorkeeper.jp/w/widget.js" type="text/javascript"></script>
-
+<div class="event-links-wrapper">
+  <div class="event-report">
+    <a href="/19/report">イベントは終了しました。レポートはこちら</a>
+  </div>
+  <div class="event-participation">
+    <a href="http://kzrb.doorkeeper.jp/events/9456" target="_blank" rel="noopener" class="nav-list-link external">
+      受付終了: Doorkeeperのページ
+      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
+    </a>
+  </div>
 </div>
 
 meetup #19

--- a/_posts/2/index.md
+++ b/_posts/2/index.md
@@ -8,8 +8,11 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/2/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
+<div class="event-links-wrapper">
+  <div class="event-report">
+    <a href="/2/report">イベントは終了しました。レポートはこちら</a>
+  </div>
+</div>
 
 meetup #2
 ==========

--- a/_posts/2/index.md
+++ b/_posts/2/index.md
@@ -8,11 +8,7 @@ next: true
 prev: true
 ---
 
-<div class="event-links-wrapper">
-  <div class="event-report">
-    <a href="/2/report">イベントは終了しました。レポートはこちら</a>
-  </div>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" %}
 
 meetup #2
 ==========

--- a/_posts/20/index.md
+++ b/_posts/20/index.md
@@ -9,17 +9,7 @@ next: true
 prev: true
 ---
 
-<div class="event-links-wrapper">
-  <div class="event-report">
-    <a href="/20/report">イベントは終了しました。レポートはこちら</a>
-  </div>
-  <div class="event-participation">
-    <a href="http://kzrb.doorkeeper.jp/events/9883" target="_blank" rel="noopener" class="nav-list-link external">
-      受付終了: Doorkeeperのページ
-      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-    </a>
-  </div>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="http://kzrb.doorkeeper.jp/events/9883" %}
 
 meetup #20
 ===========

--- a/_posts/20/index.md
+++ b/_posts/20/index.md
@@ -9,13 +9,16 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/20/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="http://kzrb.doorkeeper.jp/events/9883">meetup
-#20</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-
+<div class="event-links-wrapper">
+  <div class="event-report">
+    <a href="/20/report">イベントは終了しました。レポートはこちら</a>
+  </div>
+  <div class="event-participation">
+    <a href="http://kzrb.doorkeeper.jp/events/9883" target="_blank" rel="noopener" class="nav-list-link external">
+      受付終了: Doorkeeperのページ
+      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
+    </a>
+  </div>
 </div>
 
 meetup #20

--- a/_posts/21/index.md
+++ b/_posts/21/index.md
@@ -9,17 +9,7 @@ next: true
 prev: true
 ---
 
-<div class="event-links-wrapper">
-  <div class="event-report">
-    <a href="/21/report">イベントは終了しました。レポートはこちら</a>
-  </div>
-  <div class="event-participation">
-    <a href="http://kzrb.doorkeeper.jp/events/10910" target="_blank" rel="noopener" class="nav-list-link external">
-      受付終了: Doorkeeperのページ
-      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-    </a>
-  </div>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="http://kzrb.doorkeeper.jp/events/10910" %}
 
 meetup #21
 ===========

--- a/_posts/21/index.md
+++ b/_posts/21/index.md
@@ -9,13 +9,16 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/21/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="http://kzrb.doorkeeper.jp/events/10910">meetup
-#21</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-
+<div class="event-links-wrapper">
+  <div class="event-report">
+    <a href="/21/report">イベントは終了しました。レポートはこちら</a>
+  </div>
+  <div class="event-participation">
+    <a href="http://kzrb.doorkeeper.jp/events/10910" target="_blank" rel="noopener" class="nav-list-link external">
+      受付終了: Doorkeeperのページ
+      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
+    </a>
+  </div>
 </div>
 
 meetup #21

--- a/_posts/22/index.md
+++ b/_posts/22/index.md
@@ -9,17 +9,7 @@ next: true
 prev: true
 ---
 
-<div class="event-links-wrapper">
-  <div class="event-report">
-    <a href="/22/report">イベントは終了しました。レポートはこちら</a>
-  </div>
-  <div class="event-participation">
-    <a href="http://kzrb.doorkeeper.jp/events/10938" target="_blank" rel="noopener" class="nav-list-link external">
-      受付終了: Doorkeeperのページ
-      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-    </a>
-  </div>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="http://kzrb.doorkeeper.jp/events/10938" %}
 
 meetup #22
 ===========

--- a/_posts/22/index.md
+++ b/_posts/22/index.md
@@ -9,13 +9,16 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/22/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="http://kzrb.doorkeeper.jp/events/10938">meetup
-#22</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-
+<div class="event-links-wrapper">
+  <div class="event-report">
+    <a href="/22/report">イベントは終了しました。レポートはこちら</a>
+  </div>
+  <div class="event-participation">
+    <a href="http://kzrb.doorkeeper.jp/events/10938" target="_blank" rel="noopener" class="nav-list-link external">
+      受付終了: Doorkeeperのページ
+      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
+    </a>
+  </div>
 </div>
 
 meetup #22

--- a/_posts/23/index.md
+++ b/_posts/23/index.md
@@ -9,13 +9,16 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/23/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="http://kzrb.doorkeeper.jp/events/12981">meetup
-#23</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-
+<div class="event-links-wrapper">
+  <div class="event-report">
+    <a href="/23/report">イベントは終了しました。レポートはこちら</a>
+  </div>
+  <div class="event-participation">
+    <a href="http://kzrb.doorkeeper.jp/events/12981" target="_blank" rel="noopener" class="nav-list-link external">
+      受付終了: Doorkeeperのページ
+      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
+    </a>
+  </div>
 </div>
 
 meetup #23

--- a/_posts/23/index.md
+++ b/_posts/23/index.md
@@ -9,17 +9,7 @@ next: true
 prev: true
 ---
 
-<div class="event-links-wrapper">
-  <div class="event-report">
-    <a href="/23/report">イベントは終了しました。レポートはこちら</a>
-  </div>
-  <div class="event-participation">
-    <a href="http://kzrb.doorkeeper.jp/events/12981" target="_blank" rel="noopener" class="nav-list-link external">
-      受付終了: Doorkeeperのページ
-      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-    </a>
-  </div>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="http://kzrb.doorkeeper.jp/events/12981" %}
 
 meetup #23
 ===========

--- a/_posts/24/index.md
+++ b/_posts/24/index.md
@@ -8,13 +8,16 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/24/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="http://kzrb.doorkeeper.jp/events/13573">meetup
-#24</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-
+<div class="event-links-wrapper">
+  <div class="event-report">
+    <a href="/24/report">イベントは終了しました。レポートはこちら</a>
+  </div>
+  <div class="event-participation">
+    <a href="http://kzrb.doorkeeper.jp/events/13573" target="_blank" rel="noopener" class="nav-list-link external">
+      受付終了: Doorkeeperのページ
+      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
+    </a>
+  </div>
 </div>
 
 meetup #24

--- a/_posts/24/index.md
+++ b/_posts/24/index.md
@@ -8,17 +8,7 @@ next: true
 prev: true
 ---
 
-<div class="event-links-wrapper">
-  <div class="event-report">
-    <a href="/24/report">イベントは終了しました。レポートはこちら</a>
-  </div>
-  <div class="event-participation">
-    <a href="http://kzrb.doorkeeper.jp/events/13573" target="_blank" rel="noopener" class="nav-list-link external">
-      受付終了: Doorkeeperのページ
-      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-    </a>
-  </div>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="http://kzrb.doorkeeper.jp/events/13573" %}
 
 meetup #24
 ===========

--- a/_posts/25/index.md
+++ b/_posts/25/index.md
@@ -9,17 +9,7 @@ next: true
 prev: true
 ---
 
-<div class="event-links-wrapper">
-  <div class="event-report">
-    <a href="/25/report">イベントは終了しました。レポートはこちら</a>
-  </div>
-  <div class="event-participation">
-    <a href="http://kzrb.doorkeeper.jp/events/15010" target="_blank" rel="noopener" class="nav-list-link external">
-      受付終了: Doorkeeperのページ
-      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-    </a>
-  </div>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="http://kzrb.doorkeeper.jp/events/15010" %}
 
 meetup #25
 ===========

--- a/_posts/25/index.md
+++ b/_posts/25/index.md
@@ -9,13 +9,16 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/25/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="http://kzrb.doorkeeper.jp/events/15010">meetup
-#25</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-
+<div class="event-links-wrapper">
+  <div class="event-report">
+    <a href="/25/report">イベントは終了しました。レポートはこちら</a>
+  </div>
+  <div class="event-participation">
+    <a href="http://kzrb.doorkeeper.jp/events/15010" target="_blank" rel="noopener" class="nav-list-link external">
+      受付終了: Doorkeeperのページ
+      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
+    </a>
+  </div>
 </div>
 
 meetup #25

--- a/_posts/26/index.md
+++ b/_posts/26/index.md
@@ -9,17 +9,7 @@ next: true
 prev: true
 ---
 
-<div class="event-links-wrapper">
-  <div class="event-report">
-    <a href="/26/report">イベントは終了しました。レポートはこちら</a>
-  </div>
-  <div class="event-participation">
-    <a href="http://kzrb.doorkeeper.jp/events/15503" target="_blank" rel="noopener" class="nav-list-link external">
-      受付終了: Doorkeeperのページ
-      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-    </a>
-  </div>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="http://kzrb.doorkeeper.jp/events/15503" %}
 
 meetup #26
 ===========

--- a/_posts/26/index.md
+++ b/_posts/26/index.md
@@ -9,13 +9,16 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/26/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="http://kzrb.doorkeeper.jp/events/15503">meetup
-#26</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-
+<div class="event-links-wrapper">
+  <div class="event-report">
+    <a href="/26/report">イベントは終了しました。レポートはこちら</a>
+  </div>
+  <div class="event-participation">
+    <a href="http://kzrb.doorkeeper.jp/events/15503" target="_blank" rel="noopener" class="nav-list-link external">
+      受付終了: Doorkeeperのページ
+      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
+    </a>
+  </div>
 </div>
 
 meetup #26

--- a/_posts/27/index.md
+++ b/_posts/27/index.md
@@ -9,13 +9,16 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/27/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="http://kzrb.doorkeeper.jp/events/16428">meetup
-#27</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-
+<div class="event-links-wrapper">
+  <div class="event-report">
+    <a href="/27/report">イベントは終了しました。レポートはこちら</a>
+  </div>
+  <div class="event-participation">
+    <a href="http://kzrb.doorkeeper.jp/events/16428" target="_blank" rel="noopener" class="nav-list-link external">
+      受付終了: Doorkeeperのページ
+      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
+    </a>
+  </div>
 </div>
 
 meetup #27

--- a/_posts/27/index.md
+++ b/_posts/27/index.md
@@ -9,17 +9,7 @@ next: true
 prev: true
 ---
 
-<div class="event-links-wrapper">
-  <div class="event-report">
-    <a href="/27/report">イベントは終了しました。レポートはこちら</a>
-  </div>
-  <div class="event-participation">
-    <a href="http://kzrb.doorkeeper.jp/events/16428" target="_blank" rel="noopener" class="nav-list-link external">
-      受付終了: Doorkeeperのページ
-      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-    </a>
-  </div>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="http://kzrb.doorkeeper.jp/events/16428" %}
 
 meetup #27
 ===========

--- a/_posts/28/index.md
+++ b/_posts/28/index.md
@@ -9,13 +9,16 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/28/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
-
-<div class="doorkeeper-widget">
-<a href="http://kzrb.doorkeeper.jp/events/17763" class="doorkeeper-registration-widget">meetup
-#28</a><script src="https://widgets.doorkeeper.jp/w/widget.js" type="text/javascript"></script>
-
+<div class="event-links-wrapper">
+  <div class="event-report">
+    <a href="/28/report">イベントは終了しました。レポートはこちら</a>
+  </div>
+  <div class="event-participation">
+    <a href="http://kzrb.doorkeeper.jp/events/17763" target="_blank" rel="noopener" class="nav-list-link external">
+      受付終了: Doorkeeperのページ
+      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
+    </a>
+  </div>
 </div>
 
 meetup #28

--- a/_posts/28/index.md
+++ b/_posts/28/index.md
@@ -9,17 +9,7 @@ next: true
 prev: true
 ---
 
-<div class="event-links-wrapper">
-  <div class="event-report">
-    <a href="/28/report">イベントは終了しました。レポートはこちら</a>
-  </div>
-  <div class="event-participation">
-    <a href="http://kzrb.doorkeeper.jp/events/17763" target="_blank" rel="noopener" class="nav-list-link external">
-      受付終了: Doorkeeperのページ
-      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-    </a>
-  </div>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="http://kzrb.doorkeeper.jp/events/17763" %}
 
 meetup #28
 ===========

--- a/_posts/29/index.md
+++ b/_posts/29/index.md
@@ -9,13 +9,16 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/29/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="http://kzrb.doorkeeper.jp/events/19162">meetup
-#29</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-
+<div class="event-links-wrapper">
+  <div class="event-report">
+    <a href="/29/report">イベントは終了しました。レポートはこちら</a>
+  </div>
+  <div class="event-participation">
+    <a href="http://kzrb.doorkeeper.jp/events/19162" target="_blank" rel="noopener" class="nav-list-link external">
+      受付終了: Doorkeeperのページ
+      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
+    </a>
+  </div>
 </div>
 
 meetup #29

--- a/_posts/29/index.md
+++ b/_posts/29/index.md
@@ -9,17 +9,7 @@ next: true
 prev: true
 ---
 
-<div class="event-links-wrapper">
-  <div class="event-report">
-    <a href="/29/report">イベントは終了しました。レポートはこちら</a>
-  </div>
-  <div class="event-participation">
-    <a href="http://kzrb.doorkeeper.jp/events/19162" target="_blank" rel="noopener" class="nav-list-link external">
-      受付終了: Doorkeeperのページ
-      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-    </a>
-  </div>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="http://kzrb.doorkeeper.jp/events/19162" %}
 
 meetup #29
 ===========

--- a/_posts/3/index.md
+++ b/_posts/3/index.md
@@ -8,8 +8,11 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/3/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
+<div class="event-links-wrapper">
+  <div class="event-report">
+    <a href="/3/report">イベントは終了しました。レポートはこちら</a>
+  </div>
+</div>
 
 meetup #3
 ==========

--- a/_posts/3/index.md
+++ b/_posts/3/index.md
@@ -8,11 +8,7 @@ next: true
 prev: true
 ---
 
-<div class="event-links-wrapper">
-  <div class="event-report">
-    <a href="/3/report">イベントは終了しました。レポートはこちら</a>
-  </div>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" %}
 
 meetup #3
 ==========

--- a/_posts/30/index.md
+++ b/_posts/30/index.md
@@ -9,17 +9,7 @@ next: true
 prev: true
 ---
 
-<div class="event-links-wrapper">
-  <div class="event-report">
-    <a href="/30/report">イベントは終了しました。レポートはこちら</a>
-  </div>
-  <div class="event-participation">
-    <a href="http://kzrb.doorkeeper.jp/events/20088" target="_blank" rel="noopener" class="nav-list-link external">
-      受付終了: Doorkeeperのページ
-      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-    </a>
-  </div>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="http://kzrb.doorkeeper.jp/events/20088" %}
 
 meetup #30
 ===========

--- a/_posts/30/index.md
+++ b/_posts/30/index.md
@@ -9,13 +9,16 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/30/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="http://kzrb.doorkeeper.jp/events/20088">meetup
-#30</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-
+<div class="event-links-wrapper">
+  <div class="event-report">
+    <a href="/30/report">イベントは終了しました。レポートはこちら</a>
+  </div>
+  <div class="event-participation">
+    <a href="http://kzrb.doorkeeper.jp/events/20088" target="_blank" rel="noopener" class="nav-list-link external">
+      受付終了: Doorkeeperのページ
+      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
+    </a>
+  </div>
 </div>
 
 meetup #30

--- a/_posts/31/index.md
+++ b/_posts/31/index.md
@@ -9,14 +9,7 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/31/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/21615">meetup
-#31</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/21615" %}
 
 meetup #31
 ===========

--- a/_posts/32/index.md
+++ b/_posts/32/index.md
@@ -9,14 +9,7 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/32/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/22832">meetup
-#32</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/22832" %}
 
 meetup #32
 ===========

--- a/_posts/33/index.md
+++ b/_posts/33/index.md
@@ -9,14 +9,7 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/33/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/24598">meetup
-#33</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/24598" %}
 
 meetup #33
 ===========

--- a/_posts/34/index.md
+++ b/_posts/34/index.md
@@ -9,8 +9,7 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/34/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
+{% include event_links.html is_event_open_or_closed="closed" %}
 
 meetup #34
 ===========

--- a/_posts/35/index.md
+++ b/_posts/35/index.md
@@ -9,14 +9,7 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/35/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/27440">meetup
-#35</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/27440" %}
 
 meetup #35
 ===========

--- a/_posts/36/index.md
+++ b/_posts/36/index.md
@@ -9,14 +9,7 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/36/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/29067">meetup
-#36</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/29067" %}
 
 meetup #36
 ===========

--- a/_posts/37/index.md
+++ b/_posts/37/index.md
@@ -9,14 +9,7 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/37/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/30993">meetup
-#37</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/30993" %}
 
 meetup #37
 ===========

--- a/_posts/38/index.md
+++ b/_posts/38/index.md
@@ -9,14 +9,7 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/38/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/32361">meetup
-#38</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/32361" %}
 
 meetup #38
 ===========

--- a/_posts/39/index.md
+++ b/_posts/39/index.md
@@ -9,14 +9,7 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/39/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/33547">meetup
-#39</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/33547" %}
 
 meetup #39
 ===========

--- a/_posts/4/index.md
+++ b/_posts/4/index.md
@@ -8,17 +8,7 @@ next: true
 prev: true
 ---
 
-<div class="event-links-wrapper">
-  <div class="event-report">
-    <a href="/4/report">イベントは終了しました。レポートはこちら</a>
-  </div>
-  <div class="event-participation">
-    <a href="http://kzrb.doorkeeper.jp/events/2048" target="_blank" rel="noopener" class="nav-list-link external">
-      受付終了: Doorkeeperのページ
-      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-    </a>
-  </div>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="http://kzrb.doorkeeper.jp/events/2048" %}
 
 meetup #4
 ==========

--- a/_posts/4/index.md
+++ b/_posts/4/index.md
@@ -8,15 +8,13 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/4/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
-
-<div class="doorkeeper-widget">
-<a href="http://kzrb.doorkeeper.jp/events/2048" class="doorkeeper-registration-widget">meetup
-#4</a>
-
-<script src="https://d1dqic1fklzs1z.cloudfront.net/assets/widget.js" type="text/javascript">
-</script>
+<div class="event-links-wrapper">
+  <div class="event-report">
+    <a href="/4/report">イベントは終了しました。レポートはこちら</a>
+  </div>
+  <div>
+    <a href="http://kzrb.doorkeeper.jp/events/2048">meetup #4</a>
+  </div>
 </div>
 
 meetup #4

--- a/_posts/4/index.md
+++ b/_posts/4/index.md
@@ -12,8 +12,11 @@ prev: true
   <div class="event-report">
     <a href="/4/report">イベントは終了しました。レポートはこちら</a>
   </div>
-  <div>
-    <a href="http://kzrb.doorkeeper.jp/events/2048">meetup #4</a>
+  <div class="event-participation">
+    <a href="http://kzrb.doorkeeper.jp/events/2048" target="_blank" rel="noopener" class="nav-list-link external">
+      受付終了: Doorkeeperのページ
+      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
+    </a>
   </div>
 </div>
 

--- a/_posts/40/index.md
+++ b/_posts/40/index.md
@@ -9,14 +9,7 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/40/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/35492">meetup
-#40</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/35492" %}
 
 meetup #40
 ===========

--- a/_posts/41/index.md
+++ b/_posts/41/index.md
@@ -9,14 +9,7 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/41/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/36249">meetup
-#41</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/36249" %}
 
 meetup #41
 ===========

--- a/_posts/42/index.md
+++ b/_posts/42/index.md
@@ -51,7 +51,13 @@ prev: true
 
 ## ゲストプロフィール
 
-<img style="float: right; margin-left: 1em;" src="hiranabe.jpg" alt="hiranabe">
+<div class="guest-profile">
+<div class="guest-image" markdown="1">
+
+![hiranabe](hiranabe.jpg)
+
+</div>
+<div markdown="1">
 
 **平鍋　健児（ひらなべ　けんじ）**
 
@@ -60,6 +66,8 @@ prev: true
 
 さらに詳しいプロフィールにつきましては、[こちら](https://anagileway.wordpress.com/about/) や [ポジションペーパー](https://gist.github.com/kenjihiranabe/11459530f874a371872f) をご参照ください。
 
+</div>
+</div>
 
 ## ポジションペーパーについて
 

--- a/_posts/42/index.md
+++ b/_posts/42/index.md
@@ -8,11 +8,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/42/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/36346">meetup #42</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/36346" %}
 
 # meetup #42
 

--- a/_posts/43/index.md
+++ b/_posts/43/index.md
@@ -8,11 +8,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/43/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/39942">meetup #43</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/39942" %}
 
 # meetup #43
 

--- a/_posts/44/index.md
+++ b/_posts/44/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/44/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/41938">meetup #44</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/41938" %}
 
 # meetup #44
 

--- a/_posts/45/index.md
+++ b/_posts/45/index.md
@@ -8,11 +8,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/45/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/43523">kanazawa.rb meetup #45</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/43523" %}
 
 # meetup #45
 

--- a/_posts/46/index.md
+++ b/_posts/46/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/46/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/46236">kanazawa.rb meetup #46</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/46236" %}
 
 # meetup #46
 

--- a/_posts/47/index.md
+++ b/_posts/47/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/47/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/47493">kanazawa.rb meetup #47</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/47493" %}
 
 # meetup #47
 

--- a/_posts/48/index.md
+++ b/_posts/48/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/48/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/49419">kanazawa.rb meetup #48</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/49419" %}
 
 # meetup #48
 

--- a/_posts/49/index.md
+++ b/_posts/49/index.md
@@ -9,7 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/49/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
+{% include event_links.html is_event_open_or_closed="closed" %}
 
 # Elastic勉強会 in Kanazawa (meetup #49)
 

--- a/_posts/5/index.md
+++ b/_posts/5/index.md
@@ -12,8 +12,11 @@ prev: true
   <div class="event-report">
     <a href="/5/report">イベントは終了しました。レポートはこちら</a>
   </div>
-  <div>
-    <a href="http://kzrb.doorkeeper.jp/events/2380">meetup #5</a>
+  <div class="event-participation">
+    <a href="http://kzrb.doorkeeper.jp/events/2380" target="_blank" rel="noopener" class="nav-list-link external">
+      受付終了: Doorkeeperのページ
+      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
+    </a>
   </div>
 </div>
 

--- a/_posts/5/index.md
+++ b/_posts/5/index.md
@@ -8,17 +8,7 @@ next: true
 prev: true
 ---
 
-<div class="event-links-wrapper">
-  <div class="event-report">
-    <a href="/5/report">イベントは終了しました。レポートはこちら</a>
-  </div>
-  <div class="event-participation">
-    <a href="http://kzrb.doorkeeper.jp/events/2380" target="_blank" rel="noopener" class="nav-list-link external">
-      受付終了: Doorkeeperのページ
-      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-    </a>
-  </div>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="http://kzrb.doorkeeper.jp/events/2380" %}
 
 meetup #5
 ==========

--- a/_posts/5/index.md
+++ b/_posts/5/index.md
@@ -8,15 +8,13 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/5/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
-
-<div class="doorkeeper-widget">
-<a href="http://kzrb.doorkeeper.jp/events/2380" class="doorkeeper-registration-widget">meetup
-#5</a>
-
-<script src="https://d1dqic1fklzs1z.cloudfront.net/assets/widget.js" type="text/javascript">
-</script>
+<div class="event-links-wrapper">
+  <div class="event-report">
+    <a href="/5/report">イベントは終了しました。レポートはこちら</a>
+  </div>
+  <div>
+    <a href="http://kzrb.doorkeeper.jp/events/2380">meetup #5</a>
+  </div>
 </div>
 
 meetup #5

--- a/_posts/50/index.md
+++ b/_posts/50/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/50/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/52079">kanazawa.rb meetup #50</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/52079" %}
 
 # meetup #50
 

--- a/_posts/51/index.md
+++ b/_posts/51/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/51/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/53553">kanazawa.rb meetup #51</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/53553" %}
 
 # meetup #51
 

--- a/_posts/52/index.md
+++ b/_posts/52/index.md
@@ -9,12 +9,7 @@ next: true
 prev: true
 ---
 
-
-<div style="text-align: right;"><a href="/52/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/54817">kanazawa.rb meetup #52</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/54817" %}
 
 # meetup #52
 

--- a/_posts/53/index.md
+++ b/_posts/53/index.md
@@ -9,12 +9,7 @@ next: true
 prev: true
 ---
 
-
-<div style="text-align: right;"><a href="/53/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/55655">kanazawa.rb meetup #53</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/55655" %}
 
 # meetup #53
 

--- a/_posts/54/index.md
+++ b/_posts/54/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/54/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/56924">kanazawa.rb meetup #54</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/56924" %}
 
 # meetup #54
 

--- a/_posts/55/index.md
+++ b/_posts/55/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/55/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/57837">kanazawa.rb meetup #55</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/57837" %}
 
 # meetup #55
 

--- a/_posts/56/index.md
+++ b/_posts/56/index.md
@@ -9,13 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/56/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="http://kzrb.doorkeeper.jp/events/58873">meetup
-#56</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="http://kzrb.doorkeeper.jp/events/58873" %}
 
 meetup #56
 ===========

--- a/_posts/57/index.md
+++ b/_posts/57/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/57/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/59763">kanazawa.rb meetup #57</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/59763" %}
 
 # meetup #57
 

--- a/_posts/58/index.md
+++ b/_posts/58/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/58/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/61003">kanazawa.rb meetup #58 開発環境自慢 LT 〜 Kanazawa.rb vs ふくもく会</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/61003" %}
 
 # meetup #58
 

--- a/_posts/59/index.md
+++ b/_posts/59/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/59/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/62196">kanazawa.rb meetup #59</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/62196" %}
 
 # meetup #59
 

--- a/_posts/6/index.md
+++ b/_posts/6/index.md
@@ -12,8 +12,11 @@ prev: true
   <div class="event-report">
     <a href="/6/report">イベントは終了しました。レポートはこちら</a>
   </div>
-  <div>
-    <a href="http://kzrb.doorkeeper.jp/events/2606">meetup #6</a>
+  <div class="event-participation">
+    <a href="http://kzrb.doorkeeper.jp/events/2606" target="_blank" rel="noopener" class="nav-list-link external">
+      受付終了: Doorkeeperのページ
+      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
+    </a>
   </div>
 </div>
 

--- a/_posts/6/index.md
+++ b/_posts/6/index.md
@@ -69,7 +69,13 @@ IIJ GIO
 ゲストプロフィール
 ------------------
 
-<img style="float: right; margin-left: 1em;" src="hirolovesbeer.jpg" alt="hirolovesbeer">
+<div class="guest-profile">
+<div class="guest-image" markdown="1">
+
+![hirolovesbeer](hirolovesbeer.jpg)
+
+</div>
+<div markdown="1">
 
 **阿部博（あべひろし）**
 
@@ -84,6 +90,9 @@ IIJ GIO
 GIOのシステム開発に携わり、現在はIIJで開発するPaaS、MOGOKの開発リーダーを務める。
 
 * Twitter : <http://twitter.com/hirolovesbeer>
+
+</div>
+</div>
 
 参考
 ----

--- a/_posts/6/index.md
+++ b/_posts/6/index.md
@@ -8,15 +8,13 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/6/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
-
-<div class="doorkeeper-widget">
-<a href="http://kzrb.doorkeeper.jp/events/2606" class="doorkeeper-registration-widget">meetup
-#6</a>
-
-<script src="https://d1dqic1fklzs1z.cloudfront.net/assets/widget.js" type="text/javascript">
-</script>
+<div class="event-links-wrapper">
+  <div class="event-report">
+    <a href="/6/report">イベントは終了しました。レポートはこちら</a>
+  </div>
+  <div>
+    <a href="http://kzrb.doorkeeper.jp/events/2606">meetup #6</a>
+  </div>
 </div>
 
 meetup #6

--- a/_posts/6/index.md
+++ b/_posts/6/index.md
@@ -8,17 +8,7 @@ next: true
 prev: true
 ---
 
-<div class="event-links-wrapper">
-  <div class="event-report">
-    <a href="/6/report">イベントは終了しました。レポートはこちら</a>
-  </div>
-  <div class="event-participation">
-    <a href="http://kzrb.doorkeeper.jp/events/2606" target="_blank" rel="noopener" class="nav-list-link external">
-      受付終了: Doorkeeperのページ
-      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-    </a>
-  </div>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="http://kzrb.doorkeeper.jp/events/2606" %}
 
 meetup #6
 ==========

--- a/_posts/60/index.md
+++ b/_posts/60/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/60/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/63143">kanazawa.rb meetup #60</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/63143" %}
 
 # meetup #60
 

--- a/_posts/61/index.md
+++ b/_posts/61/index.md
@@ -9,7 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/61/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
+{% include event_links.html is_event_open_or_closed="closed" %}
 
 # GitHub勉強会 in Kanazawa (meetup #61)
 

--- a/_posts/62/index.md
+++ b/_posts/62/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/62/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/65151">kanazawa.rb meetup #62</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/65151" %}
 
 # meetup #62
 

--- a/_posts/63/index.md
+++ b/_posts/63/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/63/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/66566">kanazawa.rb meetup #63</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/66566" %}
 
 # meetup #63
 

--- a/_posts/64/index.md
+++ b/_posts/64/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/64/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/68039">kanazawa.rb meetup #64</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/68039" %}
 
 # meetup #64
 

--- a/_posts/65/index.md
+++ b/_posts/65/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/65/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/69128">kanazawa.rb meetup #65</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/69128" %}
 
 # meetup #65
 

--- a/_posts/66/index.md
+++ b/_posts/66/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/66/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/69872">kanazawa.rb meetup #66</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/69872" %}
 
 # meetup #66
 

--- a/_posts/67/index.md
+++ b/_posts/67/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/67/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/71338">kanazawa.rb meetup #67</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/71338" %}
 
 # meetup #67
 

--- a/_posts/68/index.md
+++ b/_posts/68/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/68/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/72387">kanazawa.rb meetup #68</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/72387" %}
 
 # meetup #68
 

--- a/_posts/69/index.md
+++ b/_posts/69/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/69/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/73611">kanazawa.rb meetup #69</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/73611" %}
 
 # meetup #69
 

--- a/_posts/7/index.md
+++ b/_posts/7/index.md
@@ -8,15 +8,13 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/7/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
-
-<div class="doorkeeper-widget">
-<a href="http://kzrb.doorkeeper.jp/events/3033" class="doorkeeper-registration-widget">meetup
-#7</a>
-
-<script src="https://d1dqic1fklzs1z.cloudfront.net/assets/widget.js" type="text/javascript">
-</script>
+<div class="event-links-wrapper">
+  <div class="event-report">
+    <a href="/7/report">イベントは終了しました。レポートはこちら</a>
+  </div>
+  <div>
+    <a href="http://kzrb.doorkeeper.jp/events/3033">meetup #7</a>
+  </div>
 </div>
 
 meetup #7

--- a/_posts/7/index.md
+++ b/_posts/7/index.md
@@ -12,8 +12,11 @@ prev: true
   <div class="event-report">
     <a href="/7/report">イベントは終了しました。レポートはこちら</a>
   </div>
-  <div>
-    <a href="http://kzrb.doorkeeper.jp/events/3033">meetup #7</a>
+  <div class="event-participation">
+    <a href="http://kzrb.doorkeeper.jp/events/3033" target="_blank" rel="noopener" class="nav-list-link external">
+      受付終了: Doorkeeperのページ
+      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
+    </a>
   </div>
 </div>
 

--- a/_posts/7/index.md
+++ b/_posts/7/index.md
@@ -77,7 +77,13 @@ Agile x Kanazawa.rb
 ゲストプロフィール
 ------------------
 
-<img style="margin-left: 1em; float: right" src="hiranabe.jpg" alt="hiranabe" />
+<div class="guest-profile">
+<div class="guest-image" markdown="1">
+
+![hiranabe](hiranabe.jpg)
+
+</div>
+<div markdown="1">
 
 **平鍋　健児（ひらなべ　けんじ）**
 
@@ -103,6 +109,9 @@ Agile x Kanazawa.rb
 
 -   株式会社チェンジビジョン <http://www.change-vision.com/>
 -   永和システムマネジメント <http://www.esm.co.jp/>
+
+</div>
+</div>
 
 ポジションペーパーについて
 --------------------------

--- a/_posts/7/index.md
+++ b/_posts/7/index.md
@@ -8,17 +8,7 @@ next: true
 prev: true
 ---
 
-<div class="event-links-wrapper">
-  <div class="event-report">
-    <a href="/7/report">イベントは終了しました。レポートはこちら</a>
-  </div>
-  <div class="event-participation">
-    <a href="http://kzrb.doorkeeper.jp/events/3033" target="_blank" rel="noopener" class="nav-list-link external">
-      受付終了: Doorkeeperのページ
-      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-    </a>
-  </div>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="http://kzrb.doorkeeper.jp/events/3033" %}
 
 meetup #7
 ==========

--- a/_posts/70/index.md
+++ b/_posts/70/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/70/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/73677">kanazawa.rb meetup #70</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/73677" %}
 
 # meetup #70
 

--- a/_posts/71/index.md
+++ b/_posts/71/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/71/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/76397">kanazawa.rb meetup #71</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/76397" %}
 
 # meetup #71
 

--- a/_posts/72/index.md
+++ b/_posts/72/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/72/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/77990">kanazawa.rb meetup #72</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/77990" %}
 
 # meetup #72
 

--- a/_posts/73/index.md
+++ b/_posts/73/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/73/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/79188">kanazawa.rb meetup #73</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/79188" %}
 
 # meetup #73
 

--- a/_posts/74/index.md
+++ b/_posts/74/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/74/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/80472">kanazawa.rb meetup #74</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/80472" %}
 
 # meetup #74
 

--- a/_posts/75/index.md
+++ b/_posts/75/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/75/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/81865">kanazawa.rb meetup #75</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/81865" %}
 
 # meetup #75
 

--- a/_posts/76/index.md
+++ b/_posts/76/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/76/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/83603">kanazawa.rb meetup #76</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/83603" %}
 
 # meetup #76
 

--- a/_posts/77/index.md
+++ b/_posts/77/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/77/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/84574">kanazawa.rb meetup #77</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/84574" %}
 
 # meetup #77
 

--- a/_posts/78/index.md
+++ b/_posts/78/index.md
@@ -9,12 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/78/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/86181">kanazawa.rb meetup #78</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/86181" %}
 
 # meetup #78
 

--- a/_posts/79/index.md
+++ b/_posts/79/index.md
@@ -9,8 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/79/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
+{% include event_links.html is_event_open_or_closed="closed" %}
 
 # HashiCorp Terraform & Vault Enterprise 勉強会 in 金沢 (meetup #79)
 

--- a/_posts/8/index.md
+++ b/_posts/8/index.md
@@ -12,8 +12,11 @@ prev: true
   <div class="event-report">
     <a href="/8/report">イベントは終了しました。レポートはこちら</a>
   </div>
-  <div>
-    <a href="http://kzrb.doorkeeper.jp/events/3477">meetup #8</a>
+  <div class="event-participation">
+    <a href="http://kzrb.doorkeeper.jp/events/3477" target="_blank" rel="noopener" class="nav-list-link external">
+      受付終了: Doorkeeperのページ
+      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
+    </a>
   </div>
 </div>
 

--- a/_posts/8/index.md
+++ b/_posts/8/index.md
@@ -8,17 +8,7 @@ next: true
 prev: true
 ---
 
-<div class="event-links-wrapper">
-  <div class="event-report">
-    <a href="/8/report">イベントは終了しました。レポートはこちら</a>
-  </div>
-  <div class="event-participation">
-    <a href="http://kzrb.doorkeeper.jp/events/3477" target="_blank" rel="noopener" class="nav-list-link external">
-      受付終了: Doorkeeperのページ
-      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-    </a>
-  </div>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="http://kzrb.doorkeeper.jp/events/3477" %}
 
 meetup #8
 ==========

--- a/_posts/8/index.md
+++ b/_posts/8/index.md
@@ -8,15 +8,13 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/8/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
-
-<div class="doorkeeper-widget">
-<a href="http://kzrb.doorkeeper.jp/events/3477" class="doorkeeper-registration-widget">meetup
-#8</a>
-
-<script src="https://d1dqic1fklzs1z.cloudfront.net/assets/widget.js" type="text/javascript">
-</script>
+<div class="event-links-wrapper">
+  <div class="event-report">
+    <a href="/8/report">イベントは終了しました。レポートはこちら</a>
+  </div>
+  <div>
+    <a href="http://kzrb.doorkeeper.jp/events/3477">meetup #8</a>
+  </div>
 </div>
 
 meetup #8

--- a/_posts/80/index.md
+++ b/_posts/80/index.md
@@ -9,12 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/80/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/89024">kanazawa.rb meetup #80</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/89024" %}
 
 # meetup #80
 

--- a/_posts/81/index.md
+++ b/_posts/81/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/81/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/91037">kanazawa.rb meetup #81</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/91037" %}
 
 # meetup #81
 

--- a/_posts/82/index.md
+++ b/_posts/82/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/82/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/92116">kanazawa.rb meetup #82</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/92116" %}
 
 # meetup #82
 

--- a/_posts/83/index.md
+++ b/_posts/83/index.md
@@ -9,7 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/83/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
+{% include event_links.html is_event_open_or_closed="closed" %}
 
 # Algolia 勉強会 in 金沢 (meetup #83)
 

--- a/_posts/84/index.md
+++ b/_posts/84/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/84/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/95275">kanazawa.rb meetup #84</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/95275" %}
 
 # meetup #84
 

--- a/_posts/85/index.md
+++ b/_posts/85/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/85/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/96630">kanazawa.rb meetup #85</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/96630" %}
 
 # meetup #85
 

--- a/_posts/86/index.md
+++ b/_posts/86/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/86/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/98210">kanazawa.rb meetup #86</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/98210" %}
 
 # meetup #86
 

--- a/_posts/87/index.md
+++ b/_posts/87/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/87/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/99434">kanazawa.rb meetup #87</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/99434" %}
 
 # meetup #87
 

--- a/_posts/88/index.md
+++ b/_posts/88/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/88/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/100898">kanazawa.rb meetup #88</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/100898" %}
 
 # meetup #88
 

--- a/_posts/89/index.md
+++ b/_posts/89/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/89/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/102154">kanazawa.rb meetup #89</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/102154" %}
 
 # meetup #89
 

--- a/_posts/9/index.md
+++ b/_posts/9/index.md
@@ -12,8 +12,11 @@ prev: true
   <div class="event-report">
     <a href="/9/report">イベントは終了しました。レポートはこちら</a>
   </div>
-  <div>
-    <a href="http://kzrb.doorkeeper.jp/events/3757">meetup #9</a>
+  <div class="event-participation">
+    <a href="http://kzrb.doorkeeper.jp/events/3757" target="_blank" rel="noopener" class="nav-list-link external">
+      受付終了: Doorkeeperのページ
+      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
+    </a>
   </div>
 </div>
 

--- a/_posts/9/index.md
+++ b/_posts/9/index.md
@@ -8,15 +8,13 @@ next: true
 prev: true
 ---
 
-<p>
-<a href="/9/report"><strong>イベントは終了しました。レポートはこちら</strong></a></p>
-
-<div class="doorkeeper-widget">
-<a href="http://kzrb.doorkeeper.jp/events/3757" class="doorkeeper-registration-widget">meetup
-#9</a>
-
-<script src="https://d1dqic1fklzs1z.cloudfront.net/assets/widget.js" type="text/javascript">
-</script>
+<div class="event-links-wrapper">
+  <div class="event-report">
+    <a href="/9/report">イベントは終了しました。レポートはこちら</a>
+  </div>
+  <div>
+    <a href="http://kzrb.doorkeeper.jp/events/3757">meetup #9</a>
+  </div>
 </div>
 
 meetup #9

--- a/_posts/9/index.md
+++ b/_posts/9/index.md
@@ -8,17 +8,7 @@ next: true
 prev: true
 ---
 
-<div class="event-links-wrapper">
-  <div class="event-report">
-    <a href="/9/report">イベントは終了しました。レポートはこちら</a>
-  </div>
-  <div class="event-participation">
-    <a href="http://kzrb.doorkeeper.jp/events/3757" target="_blank" rel="noopener" class="nav-list-link external">
-      受付終了: Doorkeeperのページ
-      <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-    </a>
-  </div>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="http://kzrb.doorkeeper.jp/events/3757" %}
 
 meetup #9
 ==========

--- a/_posts/90/index.md
+++ b/_posts/90/index.md
@@ -9,7 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/90/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
+{% include event_links.html is_event_open_or_closed="closed" %}
 
 # JP\_Stripes (Stripe ユーザーグループ）in 金沢 キックオフ!! with Kanazawa.rb & JAWS-UG金沢 (meetup #90)
 

--- a/_posts/91/index.md
+++ b/_posts/91/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/91/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/104870">kanazawa.rb meetup #91</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/104870" %}
 
 # meetup #91
 

--- a/_posts/92/index.md
+++ b/_posts/92/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/92/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/105712">kanazawa.rb meetup #92</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/105712" %}
 
 # meetup #92
 

--- a/_posts/93/index.md
+++ b/_posts/93/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/93/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/106321">kanazawa.rb meetup #93</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/106321" %}
 
 # meetup #93
 

--- a/_posts/94/index.md
+++ b/_posts/94/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/94/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/106933">kanazawa.rb meetup #94</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/106933" %}
 
 # meetup #94
 

--- a/_posts/95/index.md
+++ b/_posts/95/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/95/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/109126">kanazawa.rb meetup #95</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/109126" %}
 
 # meetup #95
 

--- a/_posts/96/index.md
+++ b/_posts/96/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/96/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/110088">kanazawa.rb meetup #96</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/110088" %}
 
 # meetup #96
 

--- a/_posts/97/index.md
+++ b/_posts/97/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/97/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/110869">kanazawa.rb meetup #97</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/110869" %}
 
 # meetup #97
 

--- a/_posts/98/index.md
+++ b/_posts/98/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/98/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/112882">kanazawa.rb Twilioハンズオン (meetup #98)</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/112882" %}
 
 # meetup #98
 
@@ -52,9 +48,9 @@ prev: true
 |:----------------------------------|:-----:|:----:|:--------------------------------------------------------|
 | 開場                              | 13:00 |      |                                                         |
 | 講義セッション                    | 13:15 | 15m  | Twilio 池原さん                                                        |
-| ハンズオン                        | 13:30 | 120m | Twilio 池原さん                                                        | 
-| 休憩                              | 15:30 | 15m  |                                                         | 
-| ディスカッション                  | 15:45 | 60m  |  みんな                                                       | 
+| ハンズオン                        | 13:30 | 120m | Twilio 池原さん                                                        |
+| 休憩                              | 15:30 | 15m  |                                                         |
+| ディスカッション                  | 15:45 | 60m  |  みんな                                                       |
 | クロージング                      | 16:45 | 5m   | みんな                                                  |
 
 ## 懇親会について

--- a/_posts/99/index.md
+++ b/_posts/99/index.md
@@ -9,11 +9,7 @@ next: true
 prev: true
 ---
 
-<div style="text-align: right;"><a href="/99/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
-<div class="doorkeeper-widget">
-<a class="doorkeeper-registration-widget" href="https://kzrb.doorkeeper.jp/events/113900">kanazawa.rb meetup #99</a><script src="https://widgets.doorkeeper.jp/w/widget.js"></script>
-</div>
+{% include event_links.html is_event_open_or_closed="closed" doorkeeper_url="https://kzrb.doorkeeper.jp/events/113900" %}
 
 # meetup #99
 

--- a/_posts/_plugins/file_exists.rb
+++ b/_posts/_plugins/file_exists.rb
@@ -1,0 +1,22 @@
+module Jekyll
+  class FileExistsTag < Liquid::Tag
+    def initialize(tag_name, path, tokens)
+      super
+      @path = path
+    end
+
+    def render(context)
+      # Pipe parameter through Liquid to make additional replacements possible
+      url = Liquid::Template.parse(@path).render context
+
+      # Adds the site source, so that it also works with a custom one
+      site_source = context.registers[:site].config['source']
+      file_path = site_source + '/' + url
+
+      # Check if file exists (returns true or false)
+      "#{File.exist?(file_path.strip!)}"
+    end
+  end
+end
+
+Liquid::Template.register_tag('file_exists', Jekyll::FileExistsTag)

--- a/_posts/about.md
+++ b/_posts/about.md
@@ -7,10 +7,15 @@ description: ""
 
 <section>
   <h1>Kanazawa.rbってなに</h1>
-  <img src="/images/logo_kzrb.png" style="float: left; margin-right: 2em">
-  <p>金沢市および周辺地域在住あるいはRubyやビールに興味のあるすべての人を対象にした小さな地域Rubyコミュニティです。</p>
-  <p>スタッフ的な人は何人かいますが、実はほとんど <strong>Rubyは得意ではありません</strong> (笑) Ruby興味ある、使ったらモテる、そう思っている人が自分たちで何かやってみる、そんなコミュニティです。え、興味あるの？ じゃあ来ちゃいなよ！</p>
-
+  <div class="kanazawa-rb-profile">
+    <div class="kanazawa-rb-logo">
+      <img src="/images/logo_kzrb.png">
+    </div>
+    <div>
+      <p>金沢市および周辺地域在住あるいはRubyやビールに興味のあるすべての人を対象にした小さな地域Rubyコミュニティです。</p>
+      <p>スタッフ的な人は何人かいますが、実はほとんど <strong>Rubyは得意ではありません</strong> (笑) Ruby興味ある、使ったらモテる、そう思っている人が自分たちで何かやってみる、そんなコミュニティです。え、興味あるの？ じゃあ来ちゃいなよ！</p>
+    </div>
+  </div>
   <h1 style="clear: both">展望</h1>
   <ul>
     <li>毎月第3土曜くらいに集まってなんかやる</li>

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -118,7 +118,7 @@ ul.slides {
   flex-flow: column;
 }
 
-@media (map-get($media-queries, sm) <=width) {
+@media (map-get($media-queries, sm) <= width) {
   .guest-profile {
     flex-flow: row-reverse;
 

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -35,30 +35,11 @@ ul.slides {
   }
 }
 
-// doorkeeper widget
-.doorkeeper-widget {
-  width: 300px;
-  float: right;
-  position: relative;
-  z-index: 1;
-
-  .doorkeeper-widget__text {
-    display: block;
-    text-align: right;
-
-    svg {
-      height: 1em;
-      width: 1em;
-      vertical-align: text-bottom;
-    }
-  }
-}
-
-@media screen and (max-width: 600px) {
-  .doorkeeper-widget {
-    float: none;
-    margin: 0 auto;
-    width: 100%;
+.event-participation {
+  svg {
+    height: 1em;
+    width: 1em;
+    vertical-align: text-bottom;
   }
 }
 
@@ -137,7 +118,7 @@ ul.slides {
   flex-flow: column;
 }
 
-@media (map-get($media-queries, sm) <= width) {
+@media (map-get($media-queries, sm) <=width) {
   .guest-profile {
     flex-flow: row-reverse;
 
@@ -166,4 +147,3 @@ ul.slides {
     font-weight: bold;
   }
 }
-

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -156,3 +156,14 @@ ul.slides {
     }
   }
 }
+
+.event-links-wrapper {
+  display: flex;
+  flex-flow: column;
+  align-items: flex-end;
+
+  .event-report {
+    font-weight: bold;
+  }
+}
+

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -130,3 +130,29 @@ ul.slides {
   vertical-align: middle;
   line-height: 25px;
 }
+
+.guest-profile,
+.kanazawa-rb-profile {
+  display: flex;
+  flex-flow: column;
+}
+
+@media (map-get($media-queries, sm) <= width) {
+  .guest-profile {
+    flex-flow: row-reverse;
+
+    .guest-image {
+      flex-shrink: 0;
+      margin-left: 1em;
+    }
+  }
+
+  .kanazawa-rb-profile {
+    flex-flow: row nowrap;
+
+    .kanazawa-rb-logo {
+      flex-shrink: 0;
+      margin-right: 2em;
+    }
+  }
+}

--- a/lib/meetup_template/index.md.erb
+++ b/lib/meetup_template/index.md.erb
@@ -14,7 +14,7 @@ prev: true
   - イベント参加者の募集
     - している時: is_event_open_or_closed="open"
     - していない時: is_event_open_or_closed="closed"
-  - Kanazawa.rbのDoorkeeperのイベントページ
+  - Doorkeeperのイベントページ
     - ある時: doorkeeper_url="<ここにURLを入力>"
     - ない時 <何も書かない>
 

--- a/lib/meetup_template/index.md.erb
+++ b/lib/meetup_template/index.md.erb
@@ -11,19 +11,17 @@ prev: true
 ---
 
 <!--
+  - イベント参加者の募集
+    - している時: is_event_open_or_closed="open"
+    - していない時: is_event_open_or_closed="closed"
+  - Kanazawa.rbのDoorkeeperのイベントページ
+    - ある時: doorkeeper_url="<ここにURLを入力>"
+    - ない時 <何も書かない>
 
-終了後記入
-
-<div style="text-align: right;"><a href="/<%= next_time %>/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
+is_event_open_or_closed="closed"の時にreport.mdがあればレポートページのリンクが表示される
 -->
 
-<div class="doorkeeper-widget">
-  <a href="https://kzrb.doorkeeper.jp/events/<%= doorkeeper_id %>" target="_blank" rel="noopener" class="nav-list-link external doorkeeper-widget__text">
-    Doorkeeperでの申込みはこちら
-    <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-  </a>
-</div>
+{% include event_links.html is_event_open_or_closed="open" doorkeeper_url="https://kzrb.doorkeeper.jp/events/<%= doorkeeper_id %>" %}
 
 # Meetup #<%= next_time %>
 

--- a/lib/meetup_template/lt_index.md.erb
+++ b/lib/meetup_template/lt_index.md.erb
@@ -11,19 +11,17 @@ prev: true
 ---
 
 <!--
+  - イベント参加者の募集
+    - している時: is_event_open_or_closed="open"
+    - していない時: is_event_open_or_closed="closed"
+  - Doorkeeperのイベントページ
+    - ある時: doorkeeper_url="<ここにURLを入力>"
+    - ない時 <何も書かない>
 
-終了後記入
-
-<div style="text-align: right;"><a href="/<%= next_time %>/report"><strong>イベントは終了しました。レポートはこちら</strong></a></div>
-
+is_event_open_or_closed="closed"の時にreport.mdがあればレポートページのリンクが表示される
 -->
 
-<div class="doorkeeper-widget">
-  <a href="https://kzrb.doorkeeper.jp/events/<%= doorkeeper_id %>" target="_blank" rel="noopener" class="nav-list-link external doorkeeper-widget__text">
-    Doorkeeperでの申込みはこちら
-    <svg viewBox="0 0 24 24" aria-labelledby="svg-external-link-title"><use xlink:href="#svg-external-link"></use></svg>
-  </a>
-</div>
+{% include event_links.html is_event_open_or_closed="open" doorkeeper_url="https://kzrb.doorkeeper.jp/events/<%= doorkeeper_id %>" %}
 
 # Meetup #<%= next_time %>
 

--- a/lib/tasks/generate_meetup.rake
+++ b/lib/tasks/generate_meetup.rake
@@ -117,6 +117,7 @@ namespace :meetup do
       e.generate_file(e.dest_dir, 'report.md')
     }
     event.enable_link_in_prev_report
+    event.change_is_event_open_or_closed_to_closed_in_prev_index
 
     if exist_index?(current_time)
       event.replace_doorkeeper_guide_wording

--- a/lib/tasks/generate_meetup.rake
+++ b/lib/tasks/generate_meetup.rake
@@ -117,7 +117,7 @@ namespace :meetup do
       e.generate_file(e.dest_dir, 'report.md')
     }
     event.enable_link_in_prev_report
-    event.change_is_event_open_or_closed_to_closed_in_prev_index
+    event.change_is_event_open_or_closed_to_closed_in_current_index
 
     if exist_index?(current_time)
       event.replace_doorkeeper_guide_wording

--- a/lib/tasks/meetup.rb
+++ b/lib/tasks/meetup.rb
@@ -150,6 +150,12 @@ module Meetup
       File.write(prev_index_path, str)
     end
 
+    def change_is_event_open_or_closed_to_closed_in_prev_index
+      prev_index_path = File.join(ROOT_PATH, "_posts", "#{@number - 1}", "index.md")
+      str = File.read(prev_index_path).sub(/(event_links\.html\s+is_event_open_or_closed\s*=\s*")open(")/, '\1closed\2')
+      File.write(prev_index_path, str)
+    end
+
     def enable_link_in_prev_report
       prev_report_path = File.join(ROOT_PATH, "_posts", "#{@number - 1}", "report.md")
       str = File.read(prev_report_path).sub("#next", "next")

--- a/lib/tasks/meetup.rb
+++ b/lib/tasks/meetup.rb
@@ -150,10 +150,10 @@ module Meetup
       File.write(prev_index_path, str)
     end
 
-    def change_is_event_open_or_closed_to_closed_in_prev_index
-      prev_index_path = File.join(ROOT_PATH, "_posts", "#{@number - 1}", "index.md")
-      str = File.read(prev_index_path).sub(/(event_links\.html\s+is_event_open_or_closed\s*=\s*")open(")/, '\1closed\2')
-      File.write(prev_index_path, str)
+    def change_is_event_open_or_closed_to_closed_in_current_index
+      current_index_path = File.join(ROOT_PATH, "_posts", "#{@number}", "index.md")
+      str = File.read(current_index_path).sub(/(event_links\.html\s+is_event_open_or_closed\s*=\s*")open(")/, '\1closed\2')
+      File.write(current_index_path, str)
     end
 
     def enable_link_in_prev_report


### PR DESCRIPTION
# 概要
- CSSのfloatプロパティーをFlexboxに置き換える
  - ゲストのプロフィールのテキストと画像をFlexboxで横並びにする 
  - Kanazawa.rbのプロフィールのテキストと画像をFlexboxで横並びにする 
  - /:id/index.mdの上部のリンクの余白をFlexboxで削除する
    - /:id/index.mdの上部のリンクを_includesのテンプレート (_includes/event_links.html) にする
    - Rakeタスクでindex.mdやreport.mdを生成する時にerbテンプレート内で_includes/event_links.htmlを呼び出す
    - _includes/event_links.htmlを使いやすくするために、report.mdがあるかどうかを判定するためのタグを追加する

# レビューしてほしいこと
- floatをFlexboxに置き換えた箇所のレイアウトが適切かどうか
- rake meetup:gen_indexやrake meetup:gen_reportを実行したときの挙動が適切かどうか
- index.mdに記述される、event_links.htmlの呼び出し方を説明するコメントが分かりやすいかどうか

# 参考
- [Wolfr/jekyll_file_exists: Check for existence of a file with this Jekyll plugin](https://github.com/Wolfr/jekyll_file_exists)