### PR TITLE
update copyright years

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -108,7 +108,7 @@ nav_external_links:
 back_to_top: true
 back_to_top_text: "Back to top"
 
-footer_content: "Copyright &copy; 2012 Kanazawa.rb"
+footer_content: "Copyright &copy; 2012-2024 Kanazawa.rb"
 
 # Footer last edited timestamp
 last_edit_timestamp: true # show or hide edit time - page must have `last_modified_date` defined in the frontmatter


### PR DESCRIPTION
https://github.com/kanazawarb/meetup/issues/1427 対応

確か、必須は「最初の発行年」のみでよい。
けど、更新年を併記するのもあり。

参考 https://kaikoku.blam.co.jp/client/digimaguild/knowledge/affiliate/1521

> 2000年にホームページを開設して2020年に更新した例：
> © 2000-2020 ABC Inc.

アクティブに活動していることを示す意味でも、`-2024` を追加すると良さそう。
ということで、追記。