### PR TITLE
パパロクのURLをGoogle Mapにした

### DIFF
--- a/_posts/160/index.md
+++ b/_posts/160/index.md
@@ -148,7 +148,7 @@ Gist 用のテンプレートも用意しました。fork して書き換える�
 以下のように懇親会を予定しています。
 
 * 会場 : ぱぱろく（PaPaROKU）武蔵店
-  * [食べログ](https://tabelog.com/ishikawa/A1701/A170101/17000552/)
+  * [Google Map](https://maps.app.goo.gl/Uj53x2J63itQwMNP6)
 * 会費 : 5,000円
   * 飲み放題込みの価格です
   * あくまで目安であり前後する可能性があります


### PR DESCRIPTION
Google Mapに乗ってる電話番号に電話して以下確認した。

- ちゃんとやってる
- ひとり5,000円
- 今10人ときいてるけど、人数確定は3日前ぐらいに教えてー

食べログのURLの先だとなんかマジでやってないか心配になっちゃうんで、生きてるGoogle Mapのほうにしました。

Change venue link to Google Maps
Updated venue link from Tabelog to Google Maps.