### PR TITLE
更新年を自動で生成するようにした。

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -108,7 +108,7 @@ nav_external_links:
 back_to_top: true
 back_to_top_text: "Back to top"
 
-footer_content: "Copyright &copy; 2012-2024 Kanazawa.rb"
+footer_content: "Copyright &copy; 2012-%Y Kanazawa.rb" # %Yは最終ビルドの年に置き換えます
 
 # Footer last edited timestamp
 last_edit_timestamp: true # show or hide edit time - page must have `last_modified_date` defined in the frontmatter

--- a/_includes/footer_custom.html
+++ b/_includes/footer_custom.html
@@ -1,3 +1,6 @@
 {%- if site.footer_content -%}
-  <p class="text-small text-grey-dk-100 mb-0">{{ site.footer_content }}</p>
+  <p class="text-small text-grey-dk-100 mb-0">
+    {% assign current_year = site.time | date: '%Y' %}
+    {{ site.footer_content | replace: '%Y', current_year }}
+  </p>
 {%- endif -%}


### PR DESCRIPTION
このプルリクエストは、フッターに表示する年をハードコードするのではなく、常に現在の年を動的に表示するように更新します。これにより、手動で更新しなくても著作権表示の年が常に正確に保たれます。

# フッターの改善点:
- _config.yml の footer_content を、年を表すプレースホルダーとして %Y を使うよう変更しました（ビルド時の年に置き換えられることを説明するコメントも追加）。

- _includes/footer_custom.html を更新し、Liquid テンプレートを用いてビルド時に footer_content 内の %Y を現在の年に置換するようにしました。