### PR TITLE
Slack アーカイブの時刻を JST で表示するよう修正

### DIFF
--- a/.github/workflows/add_slack_archive.yml
+++ b/.github/workflows/add_slack_archive.yml
@@ -28,6 +28,10 @@ permissions:
 
 env:
   SLAPEX_VERSION: v1.2.0
+  # slapex は投稿時刻を実行環境の local timezone で描画する。runner は UTC のため、
+  # 指定しないとログの時刻が JST から 9 時間ずれる。
+  # 取得範囲は --from/--to に明示 offset を渡しているので TZ には依存しない
+  TZ: Asia/Tokyo
 
 jobs:
   detect:


### PR DESCRIPTION
## Summary

生成される Slack アーカイブの投稿時刻が JST ではなく UTC で表示されていた問題を修正する。workflow に `TZ: Asia/Tokyo` を設定する。

初回の実運用（#1590 のマージ起因で生成された #1591）で発覚した。

## 原因

slapex は投稿時刻を**実行環境の local timezone** で描画する。GitHub Actions の runner は UTC のため、`TZ` を設定していないと JST から 9 時間ずれて表示される。slapex 側の不具合ではなく、workflow 側の設定漏れ。

#1591 の `index.html` のフッターに、slapex 自身が実行環境の timezone を出力していた。

```
Exported  2026-07-20 06:01 (UTC+00:00) / 2026-07-20T06:01:33Z
Range     From 2026-07-17T00:00:00+09:00 (included); to 2026-07-20T00:00:00+09:00 (not included); timezone: UTC+09:00
```

投稿時刻の表示（`2026-07-18 03:45`）が絶対時刻（`2026-07-18T03:45:17Z`）と一致しており、UTC のまま描画されていることが確認できる。meetup167 は 13:00 JST 開始で、最初の投稿 03:45 UTC = 12:45 JST と辻褄も合う。

なお **取得範囲は元から正しい**。`--from` / `--to` には明示 offset を渡しているため TZ に依存せず、上記 Range 行も `UTC+09:00` になっている。同一文書内で「範囲は JST・時刻は UTC」という不整合が起きていた。

## 切り分け

同一データ・同一フラグで `TZ` だけを変えて実行し、因果関係を確認した。

| 実行環境 | フッターの Exported |
|---|---|
| ローカル `TZ=UTC` | `(UTC+00:00)` |
| ローカル `TZ=Asia/Tokyo` | `(UTC+09:00)` |
| 本番（TZ 未設定の runner） | `(UTC+00:00)` |

## 動作検証

修正後、UTC のコンテナ上で act によりワークフローを実行し、生成された `index.html` が `UTC+09:00` になることを確認した。

```
archive  (act) 生成物の timezone を確認する
archive  UTC&#43;09:00
archive  Job succeeded
```

## 補足

#1589 の検証では「タイムゾーンずれは起きない」と報告したが、これは**取得範囲**についてのみ正しく、**表示**は検証できていなかった。範囲が正しいことをもって表示も問題ないと早合点していた。

既に作成済みの #1591 のアーカイブは UTC のままなので、本 PR 反映後に再生成する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
